### PR TITLE
Add $i18nPath as keyword in extractor vue-i18n

### DIFF
--- a/src/extractor/vue-i18n.js
+++ b/src/extractor/vue-i18n.js
@@ -10,6 +10,7 @@ export default async function (domainName, config, potPath) {
     const keywords = new Set(config.get('keywords', []))
     keywords.add('$t')
     keywords.add('this.$t')
+    keywords.add('$i18nPath')
 
     shell.mkdir('-p', path.dirname(potPath))
 


### PR DESCRIPTION
The main way to translate with vue-i18n is using the $t function.

However, sometimes you need to format a component in the translation string (For example: "{0} asked:", {0} being a link to the user's profile).
Vue-i18n provides you with a way to do that using the vue component "i18n".

Because of some issues, and to make detection easier, I created the $i18nPath function, which, as far as this tool is concerned, works exactly as $t.