### PR TITLE
feat(syncer-l10n-storage): add locale-sync-map and --source CLI option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# l10n-tools
+
+모노레포 구조의 l10n(번역) 도구 모음.
+
+## 스키마 생성
+
+`packages/core/l10nrc.schema.json`은 직접 수정하지 않는다. 타입 정의(`packages/core/src/config.ts`)를 수정한 뒤 아래 명령으로 생성한다:
+
+```bash
+cd packages/core && npm run schema
+```

--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -38,11 +38,12 @@ function collectKeyValue(value: string, previous: Record<string, string>): Recor
   return previous
 }
 
-function buildSyncerOptions(opts: { tags?: string, metadata?: Record<string, string>, tagMetadata?: Record<string, string> }): SyncerOptions {
+function buildSyncerOptions(opts: { tags?: string, metadata?: Record<string, string>, tagMetadata?: Record<string, string>, source?: string }): SyncerOptions {
   return {
     additionalTags: opts.tags ? opts.tags.split(',') : undefined,
     globalMetadata: opts.metadata && Object.keys(opts.metadata).length > 0 ? opts.metadata : undefined,
     tagMetadata: opts.tagMetadata && Object.keys(opts.tagMetadata).length > 0 ? opts.tagMetadata : undefined,
+    source: opts.source,
   }
 }
 
@@ -92,12 +93,14 @@ async function run() {
     tags?: string,
     metadata?: Record<string, string>,
     tagMetadata?: Record<string, string>,
+    source?: string,
   }
   program.command('upload')
     .description('Upload local changes to sync target (local files will not touched)')
     .option('-t, --tags <tags>', 'additional tags to apply when creating keys (comma separated)')
     .option('-m, --metadata <key=value>', 'global metadata to apply when creating keys (repeatable)', collectKeyValue, {})
     .option('--tag-metadata <key=value>', 'tag-specific metadata to apply when creating keys (repeatable)', collectKeyValue, {})
+    .option('--source <source>', 'source identifier for tag ownership (l10n-storage)')
     .action(async (opts: UploadOptions, cmd: Command) => {
       const syncerOptions = buildSyncerOptions(opts)
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig, skipUpload) => {
@@ -139,12 +142,14 @@ async function run() {
     tags?: string,
     metadata?: Record<string, string>,
     tagMetadata?: Record<string, string>,
+    source?: string,
   }
   program.command('sync')
     .description('Synchronize local translations and sync target')
     .option('-t, --tags <tags>', 'additional tags to apply when creating keys (comma separated)')
     .option('-m, --metadata <key=value>', 'global metadata to apply when creating keys (repeatable)', collectKeyValue, {})
     .option('--tag-metadata <key=value>', 'tag-specific metadata to apply when creating keys (repeatable)', collectKeyValue, {})
+    .option('--source <source>', 'source identifier for tag ownership (l10n-storage)')
     .action(async (opts: SyncOptions, cmd: Command) => {
       const syncerOptions = buildSyncerOptions(opts)
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig, skipUpload) => {
@@ -171,6 +176,7 @@ async function run() {
     tags?: string,
     metadata?: Record<string, string>,
     tagMetadata?: Record<string, string>,
+    source?: string,
     contexts?: string,
   }
   program.command('check')
@@ -180,6 +186,7 @@ async function run() {
     .option('-t, --tags <tags>', 'additional tags to apply when creating keys (comma separated)')
     .option('-m, --metadata <key=value>', 'global metadata to apply when creating keys (repeatable)', collectKeyValue, {})
     .option('--tag-metadata <key=value>', 'tag-specific metadata to apply when creating keys (repeatable)', collectKeyValue, {})
+    .option('--source <source>', 'source identifier for tag ownership (l10n-storage)')
     .option('-c, --contexts <contexts>', 'contexts to check (comma separated)')
     .argument('[files...]', 'files to check, if not specified, all files will be checked')
     .action(async (files: string[], opts: CheckOptions, cmd: Command) => {
@@ -381,12 +388,14 @@ async function run() {
     tags?: string,
     metadata?: Record<string, string>,
     tagMetadata?: Record<string, string>,
+    source?: string,
   }
   program.command('_sync')
     .description('Synchronize translations to remote target (internal use only)')
     .option('-t, --tags <tags>', 'additional tags to apply when creating keys (comma separated)')
     .option('-m, --metadata <key=value>', 'global metadata to apply when creating keys (repeatable)', collectKeyValue, {})
     .option('--tag-metadata <key=value>', 'tag-specific metadata to apply when creating keys (repeatable)', collectKeyValue, {})
+    .option('--source <source>', 'source identifier for tag ownership (l10n-storage)')
     .action(async (opts: InternalSyncOptions, cmd: Command) => {
       const syncerOptions = buildSyncerOptions(opts)
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig, skipUpload) => {

--- a/packages/core/l10nrc.schema.json
+++ b/packages/core/l10nrc.schema.json
@@ -210,6 +210,33 @@
       ],
       "description": "Keyword configuration for extraction\n- string: Simple keyword name (e.g., \".localized\", \"translate:1\")\n- object: Detailed configuration with parameter mapping"
     },
+    "L10nStorageConf": {
+      "additionalProperties": false,
+      "properties": {
+        "locale-sync-map": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Locale map to pass to syncer",
+          "type": "object"
+        },
+        "projectId": {
+          "type": "string"
+        },
+        "source": {
+          "description": "Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var",
+          "type": "string"
+        },
+        "url": {
+          "description": "Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var",
+          "type": "string"
+        }
+      },
+      "required": [
+        "projectId"
+      ],
+      "type": "object"
+    },
     "LokaliseConf": {
       "additionalProperties": false,
       "properties": {
@@ -265,28 +292,11 @@
       "type": "string"
     },
     "SyncTarget": {
-      "enum": ["lokalise", "l10n-storage"],
-      "type": "string"
-    },
-    "L10nStorageConf": {
-      "additionalProperties": false,
-      "properties": {
-        "url": {
-          "description": "Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var",
-          "type": "string"
-        },
-        "projectId": {
-          "type": "string"
-        },
-        "source": {
-          "description": "Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var",
-          "type": "string"
-        }
-      },
-      "required": [
-        "projectId"
+      "enum": [
+        "lokalise",
+        "l10n-storage"
       ],
-      "type": "object"
+      "type": "string"
     },
     "ValidationConf": {
       "additionalProperties": false,

--- a/packages/core/l10nrc.schema.json
+++ b/packages/core/l10nrc.schema.json
@@ -224,7 +224,7 @@
           "type": "string"
         },
         "source": {
-          "description": "Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var",
+          "description": "Source identifier for tag ownership",
           "type": "string"
         },
         "url": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -407,7 +407,7 @@ export class L10nStorageConfig {
   }
 
   getSource(): string {
-    return process.env.L10N_SOURCE ?? this.sc.source ?? 'main'
+    return this.sc.source ?? 'main'
   }
 
   getLocaleSyncMap(): { [locale: string]: string } | undefined {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -382,7 +382,7 @@ type L10nStorageConf = {
   /** Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var */
   'url'?: string,
   'projectId': string,
-  /** Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var */
+  /** Source identifier for tag ownership */
   'source'?: string,
   /** Locale map to pass to syncer */
   'locale-sync-map'?: { [locale: string]: string },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -384,6 +384,8 @@ type L10nStorageConf = {
   projectId: string,
   /** Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var */
   source?: string,
+  /** Locale map to pass to syncer */
+  'locale-sync-map'?: { [locale: string]: string },
 }
 
 export class L10nStorageConfig {
@@ -406,6 +408,10 @@ export class L10nStorageConfig {
 
   getSource(): string {
     return process.env.L10N_SOURCE ?? this.sc.source ?? 'main'
+  }
+
+  getLocaleSyncMap(): { [locale: string]: string } | undefined {
+    return this.sc['locale-sync-map']
   }
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -380,10 +380,10 @@ export class ValidationConfig {
 
 type L10nStorageConf = {
   /** Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var */
-  url?: string,
-  projectId: string,
+  'url'?: string,
+  'projectId': string,
   /** Source identifier for tag ownership. Can be overridden by L10N_SOURCE env var */
-  source?: string,
+  'source'?: string,
   /** Locale map to pass to syncer */
   'locale-sync-map'?: { [locale: string]: string },
 }

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -51,6 +51,8 @@ export interface SyncerOptions {
   globalMetadata?: Record<string, string>,
   /** Tag-specific metadata to apply when creating keys */
   tagMetadata?: Record<string, string>,
+  /** Source identifier for tag ownership (l10n-storage) */
+  source?: string,
 }
 
 /**

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -1,0 +1,232 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { KeyEntry, TransEntry } from 'l10n-tools-core'
+import type { L10nKey } from './api-types.js'
+import { buildKeyChanges } from './l10n-storage.js'
+
+function createKeyEntry(key: string, opts?: { isPlural?: boolean, context?: string | null }): KeyEntry {
+  return {
+    key,
+    isPlural: opts?.isPlural ?? false,
+    context: opts?.context ?? null,
+    references: [],
+    comments: [],
+  }
+}
+
+function createL10nKey(keyName: string, opts?: {
+  id?: string,
+  tags?: { tag: string, source: string }[],
+  metadata?: { tag: string | null, metaKey: string, metaValue: string }[],
+  translations?: { locale: string, translation: Record<string, string> }[],
+  suggestions?: { id: string, locale: string, translation: Record<string, string>, status: string }[],
+  isPlural?: boolean,
+}): L10nKey {
+  return {
+    id: opts?.id ?? Math.random().toString(),
+    keyName,
+    isPlural: opts?.isPlural ?? false,
+    tags: opts?.tags ?? [],
+    metadata: opts?.metadata ?? [],
+    translations: opts?.translations ?? [],
+    suggestions: opts?.suggestions ?? [],
+  }
+}
+
+function createTransEntry(key: string, messages: Record<string, string>, opts?: { context?: string | null, flag?: string | null }): TransEntry {
+  return {
+    key,
+    context: opts?.context ?? null,
+    messages,
+    flag: opts?.flag ?? null,
+  }
+}
+
+describe('buildKeyChanges', () => {
+  it('should create new keys when not in listedKeyMap', () => {
+    const keyEntries = [createKeyEntry('new.key')]
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, {}, {},
+    )
+
+    assert.equal(creatingKeys.length, 1)
+    assert.equal(updatingKeys.length, 0)
+    assert.equal(creatingKeys[0].keyName, 'new.key')
+    assert.deepEqual(creatingKeys[0].tags, [{ tag: 'backend', source: 'main' }])
+  })
+
+  it('should not add tag when key already has the tag with any source', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'backend', source: 'main' }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('should add tag when key exists but does not have the tag at all', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'other-tag', source: 'main' }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'backend', source: 'main' }])
+  })
+
+  it('should attach suggestions for new keys with translations', () => {
+    const keyEntries = [createKeyEntry('new.key')]
+    const allTransEntries = {
+      ko: [createTransEntry('new.key', { other: '새 키' })],
+    }
+
+    const { creatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, {},
+    )
+
+    assert.equal(creatingKeys.length, 1)
+    assert.equal(creatingKeys[0].suggestions?.length, 1)
+    assert.equal(creatingKeys[0].suggestions?.[0].locale, 'ko')
+    assert.deepEqual(creatingKeys[0].suggestions?.[0].translation, { other: '새 키' })
+  })
+
+  it('should attach suggestions for existing keys without translation or suggestion', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'backend', source: 'main' }],
+      }),
+    }
+    const allTransEntries = {
+      ko: [createTransEntry('existing.key', { other: '기존 키' })],
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    assert.equal(updatingKeys[0].suggestions?.length, 1)
+    assert.equal(updatingKeys[0].suggestions?.[0].locale, 'ko')
+  })
+
+  it('should not attach suggestion when key already has translation for locale', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'backend', source: 'main' }],
+        translations: [{ locale: 'ko', translation: { other: '이미 번역됨' } }],
+      }),
+    }
+    const allTransEntries = {
+      ko: [createTransEntry('existing.key', { other: '기존 키' })],
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('should skip translations with empty messages.other', () => {
+    const keyEntries = [createKeyEntry('new.key')]
+    const allTransEntries = {
+      ko: [createTransEntry('new.key', {})],
+    }
+
+    const { creatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, {},
+    )
+
+    assert.equal(creatingKeys[0].suggestions, undefined)
+  })
+
+  it('should apply localeSyncMap to suggestion locales', () => {
+    const keyEntries = [createKeyEntry('new.key')]
+    const allTransEntries = {
+      'zh-Hant': [createTransEntry('new.key', { other: '繁體' })],
+    }
+    const localeSyncMap = { 'zh-Hant': 'zh_TW' }
+
+    const { creatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, {}, localeSyncMap,
+    )
+
+    assert.equal(creatingKeys[0].suggestions?.length, 1)
+    assert.equal(creatingKeys[0].suggestions?.[0].locale, 'zh_TW')
+  })
+
+  it('should apply localeSyncMap when checking existing translations', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'backend', source: 'main' }],
+        translations: [{ locale: 'zh_TW', translation: { other: '已翻譯' } }],
+      }),
+    }
+    const allTransEntries = {
+      'zh-Hant': [createTransEntry('existing.key', { other: '繁體' })],
+    }
+    const localeSyncMap = { 'zh-Hant': 'zh_TW' }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, allTransEntries, listedKeyMap, localeSyncMap,
+    )
+
+    // zh_TW already has translation, so no suggestion should be added
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('Pass 1: should only remove context for own source tags', () => {
+    // key has tag from 'main' source with context 'ctx1'
+    // but local keyEntries don't have this key with context 'ctx1'
+    // → should remove context and tag for 'main' source
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      'removed.key': createL10nKey('removed.key', {
+        id: 'key-1',
+        tags: [{ tag: 'backend', source: 'main' }],
+        metadata: [{ tag: 'backend', metaKey: 'context', metaValue: '["ctx1"]' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, {}, listedKeyMap,
+    )
+
+    // Should have an update to remove context and tag
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend', source: 'main' }])
+  })
+
+  it('Pass 1: should not touch keys owned by different source', () => {
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      'other.key': createL10nKey('other.key', {
+        tags: [{ tag: 'backend', source: 'other-source' }],
+        metadata: [{ tag: 'backend', metaKey: 'context', metaValue: '' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'backend', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
+})

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -54,7 +54,7 @@ export async function syncTransToL10nStorage(
 ) {
   const storageConfig = config.getL10nStorageConfig()
   const projectId = storageConfig.getProjectId()
-  const source = storageConfig.getSource()
+  const source = options?.source ?? storageConfig.getSource()
   const url = storageConfig.getUrl()
 
   const token = process.env.TPC_AGENT_TOKEN
@@ -91,6 +91,10 @@ export async function syncTransToL10nStorage(
 
 function hasTag(tags: L10nKeyTag[], tag: string, source: string): boolean {
   return tags.some(t => t.tag === tag && t.source === source)
+}
+
+function hasTagName(tags: L10nKeyTag[], tag: string): boolean {
+  return tags.some(t => t.tag === tag)
 }
 
 function hasTranslation(key: L10nKey, locale: string): boolean {
@@ -210,7 +214,7 @@ export function buildKeyChanges(
     const listedKey = listedKeyMap[entryKey]
 
     if (listedKey != null) {
-      const needsTagAdd = !hasTag(listedKey.tags, tag, source)
+      const needsTagAdd = !hasTagName(listedKey.tags, tag)
       const needsContextUpdate = !metadataContainsContext(listedKey.metadata, tag, keyEntry.context)
       const needsDescriptionUpdate = !metadataContainsDescription(listedKey.metadata, tag, keyEntry.comments)
 

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -8,7 +8,7 @@ import {
   type TransEntry,
   type TransMessages,
 } from 'l10n-tools-core'
-import { chunk, isEqual } from 'es-toolkit/compat'
+import { chunk, invert, isEqual } from 'es-toolkit/compat'
 import { L10nStorageApiClient } from './api-client.js'
 import type {
   CreateL10nKeyInput,
@@ -49,6 +49,9 @@ export async function syncTransToL10nStorage(
     throw new Error('TPC_AGENT_TOKEN environment variable is required')
   }
 
+  const localeSyncMap = storageConfig.getLocaleSyncMap()
+  const invertedSyncMap = localeSyncMap ? invert(localeSyncMap) : undefined
+
   const apiClient = new L10nStorageApiClient(url, token)
 
   // 1. l10n-storage에서 키 전체 조회
@@ -60,11 +63,11 @@ export async function syncTransToL10nStorage(
 
   // 2. 로컬과 비교하여 create/update 대상 분류
   const { creatingKeys, updatingKeys } = buildKeyChanges(
-    source, tag, keyEntries, allTransData, listedKeyMap, options,
+    source, tag, keyEntries, allTransData, listedKeyMap, localeSyncMap, options,
   )
 
   // 3. 서버 번역을 로컬에 반영
-  updateTransEntries(tag, allTransData, listedKeyMap)
+  updateTransEntries(tag, allTransData, listedKeyMap, invertedSyncMap)
 
   // 4. l10n-storage에 업로드
   await uploadToL10nStorage(apiClient, projectId, creatingKeys, updatingKeys, skipUpload)
@@ -145,6 +148,7 @@ export function buildKeyChanges(
   keyEntries: KeyEntry[],
   allTransEntries: { [locale: string]: TransEntry[] },
   listedKeyMap: { [keyName: string]: L10nKey },
+  localeSyncMap?: { [locale: string]: string },
   options?: SyncerOptions,
 ): {
   creatingKeys: CreateL10nKeyInput[],
@@ -259,6 +263,7 @@ export function buildKeyChanges(
 
   // Pass 3: 로컬 번역 → suggestions 첨부
   for (const [locale, transEntries] of Object.entries(allTransEntries)) {
+    const serverLocale = localeSyncMap?.[locale] ?? locale
     for (const transEntry of transEntries) {
       const entryKey = transEntry.key
       if (!transEntry.messages.other) continue
@@ -266,20 +271,20 @@ export function buildKeyChanges(
       const listedKey = listedKeyMap[entryKey]
       if (listedKey != null) {
         // 기존 키: translation도 suggestion도 없는 locale만
-        if (!hasTranslation(listedKey, locale) && !hasSuggestion(listedKey, locale)) {
+        if (!hasTranslation(listedKey, serverLocale) && !hasSuggestion(listedKey, serverLocale)) {
           let updating = updatingKeyMap[entryKey]
           if (!updating) {
             updating = { keyId: listedKey.id }
             updatingKeyMap[entryKey] = updating
           }
-          pushSuggestion(updating, createSuggestion(locale, listedKey.isPlural, transEntry.messages))
+          pushSuggestion(updating, createSuggestion(serverLocale, listedKey.isPlural, transEntry.messages))
         }
       } else {
         // 새 키
         const creating = creatingKeyMap[entryKey]
-        if (creating && !creatingSuggestionHasLocale(creating, locale)) {
+        if (creating && !creatingSuggestionHasLocale(creating, serverLocale)) {
           if (!creating.suggestions) creating.suggestions = []
-          creating.suggestions.push(createSuggestion(locale, creating.isPlural ?? false, transEntry.messages))
+          creating.suggestions.push(createSuggestion(serverLocale, creating.isPlural ?? false, transEntry.messages))
         }
       }
     }
@@ -297,13 +302,14 @@ function updateTransEntries(
   tag: string,
   allTransEntries: { [locale: string]: TransEntry[] },
   listedKeyMap: { [keyName: string]: L10nKey },
+  invertedSyncMap?: { [locale: string]: string },
 ) {
   for (const [keyName, key] of Object.entries(listedKeyMap)) {
     const translatedLocales = new Set(key.translations.map(t => t.locale))
 
     // 1. 확정 번역 반영
     for (const tr of key.translations) {
-      const locale = tr.locale
+      const locale = invertedSyncMap?.[tr.locale] ?? tr.locale
       if (allTransEntries[locale] == null) continue
 
       const trans = EntryCollection.loadEntries(allTransEntries[locale])
@@ -337,7 +343,7 @@ function updateTransEntries(
     // 2. 확정 번역이 없는 locale의 pending suggestion → unverified로 반영
     for (const sugg of key.suggestions) {
       if (translatedLocales.has(sugg.locale)) continue
-      const locale = sugg.locale
+      const locale = invertedSyncMap?.[sugg.locale] ?? sugg.locale
       if (allTransEntries[locale] == null) continue
 
       const trans = EntryCollection.loadEntries(allTransEntries[locale])

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -30,6 +30,19 @@ import {
   metadataContainsDescription,
 } from './metadata.js'
 
+function assertBijectiveLocaleSyncMap(localeSyncMap: { [locale: string]: string }): void {
+  const seen: { [serverLocale: string]: string } = {}
+  for (const [localLocale, serverLocale] of Object.entries(localeSyncMap)) {
+    const existing = seen[serverLocale]
+    if (existing && existing !== localLocale) {
+      throw new Error(
+        `Invalid locale-sync-map: duplicated target locale "${serverLocale}" for "${existing}" and "${localLocale}"`,
+      )
+    }
+    seen[serverLocale] = localLocale
+  }
+}
+
 export async function syncTransToL10nStorage(
   config: L10nConfig,
   domainConfig: DomainConfig,
@@ -50,6 +63,7 @@ export async function syncTransToL10nStorage(
   }
 
   const localeSyncMap = storageConfig.getLocaleSyncMap()
+  if (localeSyncMap) assertBijectiveLocaleSyncMap(localeSyncMap)
   const invertedSyncMap = localeSyncMap ? invert(localeSyncMap) : undefined
 
   const apiClient = new L10nStorageApiClient(url, token)


### PR DESCRIPTION
## Summary
- l10n-storage syncer에 `locale-sync-map` 설정 지원 추가 (upload 시 정매핑, download 시 역매핑)
- `--source` CLI 옵션 추가 (sync, upload, check 명령) — tag 소유자 식별용
- `L10N_SOURCE` 환경변수 제거 (CLI 옵션과 설정파일로 대체)
- 같은 tag에 다른 source로 업로드 시 중복 tag 추가 방지 (`hasTagName` 도입)
- `invert()` 호출 전 bijective 매핑 검증 추가
- `buildKeyChanges` 테스트 11개 추가

## Test plan
- [x] TypeScript 타입체크 통과
- [x] 전체 테스트 통과 (lokalise 10 + l10n-storage 11)
- [x] `--source main` → `--source PR-123` 순차 업로드 시 중복 source 안 생기는 것 확인
- [x] locale-sync-map 매핑 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)