### PR TITLE
feat(cli): add plugins command to list installed plugins

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -71,6 +71,24 @@ async function run() {
       console.info('\nRC file:\n  refer to [L10nConf] type or see \'l10nrc.schema.json\'')
     })
 
+  program.command('plugins')
+    .description('List installed plugins')
+    .action(async () => {
+      for (const plugin of pluginRegistry.getPlugins().values()) {
+        const caps: string[] = []
+        if (plugin.extractors?.length) {
+          caps.push('extractors: ' + plugin.extractors.flatMap(e => e.domainTypes).join(', '))
+        }
+        if (plugin.compilers?.length) {
+          caps.push('compilers: ' + plugin.compilers.flatMap(c => Object.keys(c.compilers)).join(', '))
+        }
+        if (plugin.syncers?.length) {
+          caps.push('syncers: ' + plugin.syncers.map(s => s.syncTarget).join(', '))
+        }
+        console.log(`${plugin.name}\t${caps.join('\t')}`)
+      }
+    })
+
   program.command('update')
     .description('Update local translations')
     .action(async (opts, cmd: Command) => {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -140,7 +140,7 @@ class PluginRegistry {
     }
     const plugin = await factory()
     this.register(plugin)
-    log.info('plugin-registry', `Loaded plugin: ${plugin.name}`)
+    log.verbose('plugin-registry', `Loaded plugin: ${plugin.name}`)
   }
 
   /**
@@ -223,6 +223,13 @@ class PluginRegistry {
    */
   getSuggestedSyncerPlugin(syncTarget: string): string | undefined {
     return SYNCER_TYPE_TO_PLUGIN[syncTarget]
+  }
+
+  /**
+   * Get all loaded plugins
+   */
+  getPlugins(): ReadonlyMap<string, L10nPlugin> {
+    return this.plugins
   }
 
   /**


### PR DESCRIPTION
## Summary
- `l10n plugins` 커맨드 추가: 설치된 플러그인과 각 플러그인이 제공하는 extractor/compiler/syncer를 탭 구분으로 출력
- 플러그인 로드 로그를 `info` → `verbose`로 변경하여 일반 실행 시 불필요한 출력 제거

## Test plan
- [ ] `l10n plugins` 실행 시 설치된 플러그인 목록이 출력되는지 확인
- [ ] `l10n plugins | grep syncer` 등 grep 필터링이 정상 동작하는지 확인
- [ ] 기존 커맨드(`l10n update`, `l10n sync` 등) 실행 시 플러그인 로드 로그가 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)