### PR TITLE
feat(extractor-vue): support extra-expr-attrs config for custom directives

### DIFF
--- a/packages/core/l10nrc.schema.json
+++ b/packages/core/l10nrc.schema.json
@@ -77,6 +77,22 @@
           "description": "Default module that omits prefix in context (android only)",
           "type": "string"
         },
+        "extra-expr-attrs": {
+          "description": "Extra directive names whose attribute value should be parsed as JavaScript expressions containing translation function calls (vue extractor only).\n\nThese are appended to the built-in directive list the extractor already scans (the built-in list differs by extractor type — for example the vue-i18n extractor scans `v-html` by default while the vue-gettext extractor does not). Use this option to register custom directives such as sanitizing HTML wrappers.",
+          "examples": [
+            [
+              "v-dompurify-html"
+            ],
+            [
+              "v-dompurify-html",
+              "v-safe-html"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "fallback-locale": {
           "description": "Fill translations from fallback locale if not exists",
           "type": "string"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -96,6 +96,19 @@ type DomainConf = {
   'default-module'?: string,
   /** Lokalise platform to use */
   'lokalise-platform'?: LokalisePlatform,
+  /**
+   * Extra directive names whose attribute value should be parsed as JavaScript
+   * expressions containing translation function calls (vue extractor only).
+   *
+   * These are appended to the built-in directive list the extractor already
+   * scans (the built-in list differs by extractor type — for example the
+   * vue-i18n extractor scans `v-html` by default while the vue-gettext
+   * extractor does not). Use this option to register custom directives such
+   * as sanitizing HTML wrappers.
+   *
+   * @examples [["v-dompurify-html"], ["v-dompurify-html", "v-safe-html"]]
+   */
+  'extra-expr-attrs'?: string[],
   /** List of output formats */
   'outputs': CompilerConf[],
 }
@@ -245,6 +258,14 @@ export class DomainConfig {
 
   getCompilerConfigs(): CompilerConfig[] {
     return this.dc['outputs'].map(output => new CompilerConfig(output)) ?? []
+  }
+
+  /**
+   * Extra Vue directive names (exact match) whose attribute values should be
+   * scanned for translation function calls by the Vue extractor.
+   */
+  getExtraExprAttrs(): string[] {
+    return this.dc['extra-expr-attrs'] ?? []
   }
 }
 

--- a/packages/extractor-vue/src/extractor.ts
+++ b/packages/extractor-vue/src/extractor.ts
@@ -4,6 +4,30 @@ import * as path from 'path'
 import { type DomainConfig, getSrcPaths, writeKeyEntries } from 'l10n-tools-core'
 import { VueKeyExtractor } from './vue-key-extractor.js'
 
+/**
+ * Escape all regex metacharacters so a user-supplied directive name is
+ * treated as a literal string when compiled into a `RegExp`.
+ *
+ * This keeps the config contract simple — users declare plain directive
+ * names in `.l10nrc`, not regex patterns — and prevents accidental
+ * wildcard matching from characters like `.`, `*`, `+`, etc.
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Build additional `exprAttrs` regex patterns from the domain config.
+ *
+ * Users declare extra directive names (e.g. `v-dompurify-html`) in
+ * `.l10nrc` under `extra-expr-attrs`. Each name is escaped and compiled
+ * into an anchored exact-match regex so that it joins the built-in list
+ * used by the Vue key extractor.
+ */
+function buildExtraExprAttrs(config: DomainConfig): RegExp[] {
+  return config.getExtraExprAttrs().map(name => new RegExp(`^${escapeRegex(name)}$`))
+}
+
 export async function extractVueGettextKeys(domainName: string, config: DomainConfig, keysPath: string) {
   const srcPaths = await getSrcPaths(config, ['.vue', '.js'])
   const keywords = new Set(config.getKeywordsAsStrings())
@@ -17,7 +41,7 @@ export async function extractVueGettextKeys(domainName: string, config: DomainCo
   const extractor = new VueKeyExtractor({
     tagNames: ['translate'],
     attrNames: ['v-translate'],
-    exprAttrs: [/^:/, /^v-bind:/],
+    exprAttrs: [/^:/, /^v-bind:/, ...buildExtraExprAttrs(config)],
     markers: [{ start: '{{', end: '}}' }],
     keywords: keywords,
   })
@@ -55,7 +79,7 @@ export async function extractVueI18nKeys(domainName: string, config: DomainConfi
   const extractor = new VueKeyExtractor({
     tagNames: ['i18n', 'i18n-t'],
     objectAttrs: { 'v-t': ['', 'path'] },
-    exprAttrs: [/^:/, /^v-bind:/, /^v-html$/],
+    exprAttrs: [/^:/, /^v-bind:/, /^v-html$/, ...buildExtraExprAttrs(config)],
     markers: [{ start: '{{', end: '}}' }],
     keywords: [...keywords],
   })

--- a/packages/extractor-vue/src/vue-key-extractor.test.ts
+++ b/packages/extractor-vue/src/vue-key-extractor.test.ts
@@ -143,6 +143,66 @@ describe('VueKeyExtractor', () => {
       expectKeyEntry(extractor, null, 'key-v-t', false, 'test-file', '3')
       expectKeyEntry(extractor, null, 'key-v-t-path', false, 'test-file', '4')
     })
+
+    it('extra exprAttrs: custom directive (e.g. v-dompurify-html)', () => {
+      const module = `
+                <template>
+                    <div>
+                        <p v-html="$t('key-v-html')"></p>
+                        <p v-dompurify-html="$t('key-v-dompurify-html')"></p>
+                        <p v-safe-html="$t('key-v-safe-html')"></p>
+                    </div>
+                </template>
+            `
+      const extractor = new VueKeyExtractor({
+        exprAttrs: [/^v-html$/, /^v-dompurify-html$/, /^v-safe-html$/],
+        keywords: ['$t'],
+      })
+      extractor.extractVue('test-file', module)
+      expectKeyEntry(extractor, null, 'key-v-html', false, 'test-file', '4')
+      expectKeyEntry(extractor, null, 'key-v-dompurify-html', false, 'test-file', '5')
+      expectKeyEntry(extractor, null, 'key-v-safe-html', false, 'test-file', '6')
+    })
+
+    it('extra exprAttrs: directive not listed should be ignored', () => {
+      const module = `
+                <template>
+                    <p v-dompurify-html="$t('key-v-dompurify-html')"></p>
+                </template>
+            `
+      // Only v-html in exprAttrs, v-dompurify-html should NOT be scanned
+      const extractor = new VueKeyExtractor({
+        exprAttrs: [/^v-html$/],
+        keywords: ['$t'],
+      })
+      extractor.extractVue('test-file', module)
+      assert.equal(
+        extractor.keys.find(null, 'key-v-dompurify-html'),
+        null,
+        'key from unlisted directive should not be extracted',
+      )
+    })
+
+    it('extra exprAttrs: anchored exact match does not leak to prefixes', () => {
+      const module = `
+                <template>
+                    <p v-html="$t('key-v-html')"></p>
+                    <p v-html-foo="$t('key-v-html-foo')"></p>
+                </template>
+            `
+      // Anchored /^v-html$/ must match only exact "v-html", NOT "v-html-foo"
+      const extractor = new VueKeyExtractor({
+        exprAttrs: [/^v-html$/],
+        keywords: ['$t'],
+      })
+      extractor.extractVue('test-file', module)
+      expectKeyEntry(extractor, null, 'key-v-html', false, 'test-file', '3')
+      assert.equal(
+        extractor.keys.find(null, 'key-v-html-foo'),
+        null,
+        'prefix-matched directive should not be extracted under exact-match regex',
+      )
+    })
   })
 
   describe('script in vue file', () => {


### PR DESCRIPTION
## Summary

Adds a new optional `extra-expr-attrs` domain config field that lets users register additional Vue directive names whose attribute values should be scanned by the Vue key extractor for translation function calls.

## Problem

The current Vue extractor only scans a hardcoded set of directives (`v-html`, `v-bind:*`, `:*`) for `t('...')` calls inside their attribute values. Projects that use wrapper directives like `v-dompurify-html`, `v-safe-html`, etc. — typically for XSS-safe rendering of server-supplied HTML — silently lose their keys because the extractor cannot see `t()` calls inside those directives.

In one downstream project this caused real incidents where developers enforced `v-dompurify-html` as a replacement for `v-html` (sanitization-by-directive policy), but i18n keys inside those bindings were treated as "unused" by the extractor and removed from the locale files, breaking runtime translations.

## Solution

Add a simple config option:

```json
{
  "domains": {
    "my-app": {
      "type": "vue-i18n",
      ...
      "extra-expr-attrs": ["v-dompurify-html", "v-safe-html"]
    }
  }
}
```

Each name is escaped for regex metacharacters and compiled into an anchored exact-match pattern. The new patterns are **appended** to the built-in list (`v-html`, `v-bind:*`, `:*`), so existing projects are unaffected when the field is absent.

## Changes

- **`packages/core`**
  - `DomainConf['extra-expr-attrs']?: string[]` (optional, backward compatible)
  - `DomainConfig.getExtraExprAttrs(): string[]` getter
  - Regenerated `l10nrc.schema.json` via `npm run schema`
- **`packages/extractor-vue`**
  - New internal helpers `escapeRegex()` + `buildExtraExprAttrs()`
  - Both `extractVueGettextKeys` and `extractVueI18nKeys` spread the extras into their `exprAttrs` array

## Backward compatibility

- `extra-expr-attrs` is optional. When absent, `buildExtraExprAttrs` returns `[]` and the spread is a no-op → **`exprAttrs` is byte-for-byte identical** to before.
- No existing API/type is removed or changed.
- Plugins (`plugin-android`, `plugin-ios`, `extractor-php`, `extractor-python`, `extractor-javascript`) do not read the new field and are untouched.
- All existing tests across the monorepo pass (`core`, `extractor-javascript`, `extractor-vue`, `plugin-android`, `plugin-ios`, `syncer-l10n-storage`, `syncer-lokalise`).

## Safety: regex metacharacter escape

User-supplied directive names are escaped so plain strings work literally and wildcard characters cannot leak:

```ts
function escapeRegex(str: string): string {
  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
}
```

Example: `"v-html.*"` becomes `^v\-html\.\*$`, matching that exact literal only.

## Test plan

- [x] `npm run build` — monorepo `tsc -b` passes
- [x] `npm test` in each package — all green
- [x] New `extractor-vue` tests:
  - `extra exprAttrs: custom directive (e.g. v-dompurify-html)` (positive)
  - `extra exprAttrs: directive not listed should be ignored` (negative / regression guard)
  - `extra exprAttrs: anchored exact match does not leak to prefixes` (`^v-html$` must not match `v-html-foo`)
- [x] End-to-end verification: installed the built dist into a downstream Nuxt 4 project, added `"extra-expr-attrs": ["v-dompurify-html"]` to its `.l10nrc`, ran `l10n sync --dry-sync` — 4 previously-lost keys (`<strong>ON/OFF</strong>: ...`) were correctly preserved as in-use. Without the patch, the same run reported those keys as orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)