### PR TITLE
fix(plugin-ios): exclude framework Info.plist from glob results

### DIFF
--- a/packages/plugin-ios/src/extractor.ts
+++ b/packages/plugin-ios/src/extractor.ts
@@ -140,7 +140,13 @@ async function getInfoPlistPath(srcDir: string) {
   const srcPattern = path.join(srcDir, '**', 'Info.plist')
   const paths = await glob(srcPattern)
   const filtered = paths.filter(p => !/(\.framework|\.xcframework)[/\\]/.test(p))
-  return filtered[0] ?? paths[0]
+  if (paths.length === 0) {
+    throw new Error(`Info.plist not found under: ${srcDir}`)
+  }
+  if (filtered.length === 0) {
+    throw new Error(`No app Info.plist found outside .framework/.xcframework under: ${srcDir}`)
+  }
+  return filtered[0]
 }
 
 async function getXibPaths(srcDir: string) {

--- a/packages/plugin-ios/src/extractor.ts
+++ b/packages/plugin-ios/src/extractor.ts
@@ -139,7 +139,8 @@ export async function extractIosKeys(domainName: string, config: DomainConfig, k
 async function getInfoPlistPath(srcDir: string) {
   const srcPattern = path.join(srcDir, '**', 'Info.plist')
   const paths = await glob(srcPattern)
-  return paths[0]
+  const filtered = paths.filter(p => !/(\.framework|\.xcframework)[/\\]/.test(p))
+  return filtered[0] ?? paths[0]
 }
 
 async function getXibPaths(srcDir: string) {


### PR DESCRIPTION
## Summary
- iOS extractor의 `getInfoPlistPath()`가 `**/Info.plist` glob 결과의 첫 번째를 사용하는데, `.framework/` 또는 `.xcframework/` 내부의 Info.plist가 먼저 잡힐 경우 잘못된 plist를 파싱하는 문제 수정
- Tuist 구조 등에서 embedded framework가 src-dir 안에 존재할 때 발생할 수 있음

## Test plan
- [x] `npm run build` 통과
- [x] `npm run lint` 통과
- [x] `npm test -w packages/plugin-ios` 28개 테스트 통과
- [ ] likey-ios 프로젝트에서 `l10n extract` 실행하여 Info.plist 키 정상 추출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)