### PR TITLE
fix(core): skip write-back in upload command to prevent cache corruption

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -132,7 +132,7 @@ async function run() {
 
         await extractKeys(domainName, domainConfig, keysPath)
         await updateTrans(keysPath, transDir, transDir, locales, null)
-        await syncTransToTarget(config, domainConfig, tag, keysPath, transDir, skipUpload, { ...syncerOptions, skipWriteBack: true })
+        await syncTransToTarget(config, domainConfig, tag, keysPath, transDir, skipUpload, syncerOptions, true)
         await updateTrans(keysPath, transDir, transDir, locales, validationConfig)
       })
     })

--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -132,7 +132,7 @@ async function run() {
 
         await extractKeys(domainName, domainConfig, keysPath)
         await updateTrans(keysPath, transDir, transDir, locales, null)
-        await syncTransToTarget(config, domainConfig, tag, keysPath, transDir, skipUpload, syncerOptions)
+        await syncTransToTarget(config, domainConfig, tag, keysPath, transDir, skipUpload, { ...syncerOptions, skipWriteBack: true })
         await updateTrans(keysPath, transDir, transDir, locales, validationConfig)
       })
     })

--- a/packages/core/src/syncer.ts
+++ b/packages/core/src/syncer.ts
@@ -23,7 +23,7 @@ export async function syncTransToTarget(
   keysPath: string,
   transDir: string,
   skipUpload: boolean,
-  options?: SyncerOptions,
+  options?: SyncerOptions & { skipWriteBack?: boolean },
 ) {
   const target = config.getSyncTarget()
 
@@ -39,6 +39,8 @@ export async function syncTransToTarget(
   const keyEntries = await readKeyEntries(keysPath)
   const allTransEntries = await readAllTransEntries(transDir)
   await syncer(config, domainConfig, tag, keyEntries, allTransEntries, skipUpload, options)
-  await writeKeyEntries(keysPath, keyEntries)
-  await writeAllTransEntries(transDir, allTransEntries)
+  if (!options?.skipWriteBack) {
+    await writeKeyEntries(keysPath, keyEntries)
+    await writeAllTransEntries(transDir, allTransEntries)
+  }
 }

--- a/packages/core/src/syncer.ts
+++ b/packages/core/src/syncer.ts
@@ -23,7 +23,8 @@ export async function syncTransToTarget(
   keysPath: string,
   transDir: string,
   skipUpload: boolean,
-  options?: SyncerOptions & { skipWriteBack?: boolean },
+  options?: SyncerOptions,
+  skipWriteBack?: boolean,
 ) {
   const target = config.getSyncTarget()
 
@@ -39,7 +40,7 @@ export async function syncTransToTarget(
   const keyEntries = await readKeyEntries(keysPath)
   const allTransEntries = await readAllTransEntries(transDir)
   await syncer(config, domainConfig, tag, keyEntries, allTransEntries, skipUpload, options)
-  if (!options?.skipWriteBack) {
+  if (!skipWriteBack) {
     await writeKeyEntries(keysPath, keyEntries)
     await writeAllTransEntries(transDir, allTransEntries)
   }

--- a/packages/core/src/syncer.ts
+++ b/packages/core/src/syncer.ts
@@ -15,6 +15,7 @@ export type { SyncerFunc, SyncerOptions } from './plugin-types.js'
  * @param transDir - Directory containing translation files
  * @param skipUpload - If true, skip uploading to sync target (download only)
  * @param options - Syncer options (additional tags, metadata, etc.)
+ * @param skipWriteBack - If true, skip writing updated entries back to disk (prevents cache corruption during upload-only operations)
  */
 export async function syncTransToTarget(
   config: L10nConfig,


### PR DESCRIPTION
## Summary
- `syncTransToTarget`에 `skipWriteBack` 옵션을 추가하여 upload 커맨드에서 write-back을 건너뛰도록 변경
- CI에서 Lokalise upload 후 l10n-storage upload이 실행될 때, l10n-storage syncer의 write-back이 Lokalise 캐시를 오염시켜 후속 `check`에서 오탐이 발생하는 문제 해결
- 사전 작업으로 workflow-storage에서 Lokalise 경로를 `upload` → `sync`로 변경 완료 (tpcint/workflow-storage#44)

## Test plan
- [x] 빌드 통과 (`tsc -b`)
- [x] 린트 통과
- [x] 기존 테스트 통과
- [ ] l10n-storage 플러그인이 있는 리포에서 CI `check` 오탐이 해소되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)