### PR TITLE
feat(syncer-l10n-storage): switch sync to keys-to-serve API

### DIFF
--- a/packages/syncer-l10n-storage/src/api-client.ts
+++ b/packages/syncer-l10n-storage/src/api-client.ts
@@ -1,5 +1,5 @@
 import log from 'npmlog'
-import type { CreateL10nKeyInput, L10nKey, ListKeysResponse, UpdateL10nKeyInput } from './api-types.js'
+import type { CreateL10nKeyInput, L10nKeyToServe, ListKeysToServeResponse, UpdateL10nKeyInput } from './api-types.js'
 
 export class L10nStorageApiClient {
   private readonly baseUrl: string
@@ -39,17 +39,17 @@ export class L10nStorageApiClient {
     return await res.json() as T
   }
 
-  async listAllKeys(projectId: string): Promise<L10nKey[]> {
-    const allKeys: L10nKey[] = []
+  async listAllKeysToServe(projectId: string): Promise<L10nKeyToServe[]> {
+    const allKeys: L10nKeyToServe[] = []
     let cursor: string | undefined
     let previousCursor: string | undefined
     do {
       log.info('l10n-storage-api', `listing keys${cursor ? ` (cursor: ${cursor})` : ''}`)
-      const params = new URLSearchParams({ includeTranslations: '1', includeSuggestions: '1', limit: '500' })
+      const params = new URLSearchParams({ limit: '500' })
       if (cursor) params.set('cursor', cursor)
-      const response = await this.request<ListKeysResponse>(
+      const response = await this.request<ListKeysToServeResponse>(
         'GET',
-        `/api/l10n/projects/${projectId}/keys?${params}`,
+        `/api/l10n/projects/${projectId}/keys-to-serve?${params}`,
       )
       allKeys.push(...response.keys)
       previousCursor = cursor

--- a/packages/syncer-l10n-storage/src/api-types.ts
+++ b/packages/syncer-l10n-storage/src/api-types.ts
@@ -9,26 +9,18 @@ export interface L10nKeyMetadata {
   metaValue: string,
 }
 
-export interface L10nTranslation {
+export interface L10nServedTranslation {
   locale: string,
   translation: Record<string, string>,
 }
 
-export interface L10nSuggestion {
-  id: string,
-  locale: string,
-  translation: Record<string, string>,
-  status: string,
-}
-
-export interface L10nKey {
+export interface L10nKeyToServe {
   id: string,
   keyName: string,
   isPlural: boolean,
   tags: L10nKeyTag[],
   metadata: L10nKeyMetadata[],
-  translations: L10nTranslation[],
-  suggestions: L10nSuggestion[],
+  translations: L10nServedTranslation[],
 }
 
 export interface CreateSuggestionInput {
@@ -53,7 +45,7 @@ export interface UpdateL10nKeyInput {
   suggestions?: CreateSuggestionInput[],
 }
 
-export interface ListKeysResponse {
-  keys: L10nKey[],
+export interface ListKeysToServeResponse {
+  keys: L10nKeyToServe[],
   nextCursor: string | null,
 }

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { KeyEntry, TransEntry } from 'l10n-tools-core'
-import type { L10nKey } from './api-types.js'
+import type { L10nKeyToServe } from './api-types.js'
 import { buildKeyChanges } from './l10n-storage.js'
 
 function createKeyEntry(key: string, opts?: { isPlural?: boolean, context?: string | null }): KeyEntry {
@@ -19,9 +19,8 @@ function createL10nKey(keyName: string, opts?: {
   tags?: { tag: string, source: string }[],
   metadata?: { tag: string | null, metaKey: string, metaValue: string }[],
   translations?: { locale: string, translation: Record<string, string> }[],
-  suggestions?: { id: string, locale: string, translation: Record<string, string>, status: string }[],
   isPlural?: boolean,
-}): L10nKey {
+}): L10nKeyToServe {
   return {
     id: opts?.id ?? Math.random().toString(),
     keyName,
@@ -29,7 +28,6 @@ function createL10nKey(keyName: string, opts?: {
     tags: opts?.tags ?? [],
     metadata: opts?.metadata ?? [],
     translations: opts?.translations ?? [],
-    suggestions: opts?.suggestions ?? [],
   }
 }
 
@@ -104,7 +102,7 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(creatingKeys[0].suggestions?.[0].translation, { other: '새 키' })
   })
 
-  it('should attach suggestions for existing keys without translation or suggestion', () => {
+  it('should attach suggestions for existing keys without translation', () => {
     const keyEntries = [createKeyEntry('existing.key')]
     const listedKeyMap = {
       'existing.key': createL10nKey('existing.key', {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -13,9 +13,9 @@ import { L10nStorageApiClient } from './api-client.js'
 import type {
   CreateL10nKeyInput,
   CreateSuggestionInput,
-  L10nKey,
   L10nKeyMetadata,
   L10nKeyTag,
+  L10nKeyToServe,
   UpdateL10nKeyInput,
 } from './api-types.js'
 import {
@@ -68,9 +68,9 @@ export async function syncTransToL10nStorage(
 
   const apiClient = new L10nStorageApiClient(url, token)
 
-  // 1. l10n-storage에서 키 전체 조회
-  const listedKeys = await apiClient.listAllKeys(projectId)
-  const listedKeyMap: { [keyName: string]: L10nKey } = {}
+  // 1. l10n-storage에서 정책 적용된 키 전체 조회 (keys-to-serve)
+  const listedKeys = await apiClient.listAllKeysToServe(projectId)
+  const listedKeyMap: { [keyName: string]: L10nKeyToServe } = {}
   for (const key of listedKeys) {
     listedKeyMap[key.keyName] = key
   }
@@ -97,12 +97,8 @@ function hasTagName(tags: L10nKeyTag[], tag: string): boolean {
   return tags.some(t => t.tag === tag)
 }
 
-function hasTranslation(key: L10nKey, locale: string): boolean {
+function hasTranslation(key: L10nKeyToServe, locale: string): boolean {
   return key.translations.some(t => t.locale === locale)
-}
-
-function hasSuggestion(key: L10nKey, locale: string): boolean {
-  return key.suggestions.some(s => s.locale === locale)
 }
 
 function pushAddTag(updating: UpdateL10nKeyInput, tag: L10nKeyTag): void {
@@ -165,7 +161,7 @@ export function buildKeyChanges(
   tag: string,
   keyEntries: KeyEntry[],
   allTransEntries: { [locale: string]: TransEntry[] },
-  listedKeyMap: { [keyName: string]: L10nKey },
+  listedKeyMap: { [keyName: string]: L10nKeyToServe },
   localeSyncMap?: { [locale: string]: string },
   options?: SyncerOptions,
 ): {
@@ -288,8 +284,9 @@ export function buildKeyChanges(
 
       const listedKey = listedKeyMap[entryKey]
       if (listedKey != null) {
-        // 기존 키: translation도 suggestion도 없는 locale만
-        if (!hasTranslation(listedKey, serverLocale) && !hasSuggestion(listedKey, serverLocale)) {
+        // keys-to-serve는 정책 적용된 단일 translations만 노출. 해당 locale 항목이 없으면 suggestion 추가.
+        // 이미 pending suggestion이 서버에 있는 경우는 storage 측 dedup에 위임.
+        if (!hasTranslation(listedKey, serverLocale)) {
           let updating = updatingKeyMap[entryKey]
           if (!updating) {
             updating = { keyId: listedKey.id }
@@ -319,13 +316,12 @@ export function buildKeyChanges(
 function updateTransEntries(
   tag: string,
   allTransEntries: { [locale: string]: TransEntry[] },
-  listedKeyMap: { [keyName: string]: L10nKey },
+  listedKeyMap: { [keyName: string]: L10nKeyToServe },
   invertedSyncMap?: { [locale: string]: string },
 ) {
+  // keys-to-serve가 locale별 정책(serveSuggestions)을 이미 적용해 단일 translations로 내려주므로
+  // 클라이언트는 그대로 반영하기만 하면 된다. unverified flag는 더 이상 사용하지 않는다.
   for (const [keyName, key] of Object.entries(listedKeyMap)) {
-    const translatedLocales = new Set(key.translations.map(t => t.locale))
-
-    // 1. 확정 번역 반영
     for (const tr of key.translations) {
       const locale = invertedSyncMap?.[tr.locale] ?? tr.locale
       if (allTransEntries[locale] == null) continue
@@ -352,40 +348,6 @@ function updateTransEntries(
           const value = tr.translation.other
           if (value && value !== transEntry.messages.other) {
             log.verbose('updateTransEntries', `updating ${locale} value of ${keyName}`)
-            transEntry.messages = { other: value }
-          }
-        }
-      }
-    }
-
-    // 2. 확정 번역이 없는 locale의 pending suggestion → unverified로 반영
-    for (const sugg of key.suggestions) {
-      if (translatedLocales.has(sugg.locale)) continue
-      const locale = invertedSyncMap?.[sugg.locale] ?? sugg.locale
-      if (allTransEntries[locale] == null) continue
-
-      const trans = EntryCollection.loadEntries(allTransEntries[locale])
-      const contexts = [...getContextsFromMetadata(key.metadata, tag), null]
-
-      for (const keyContext of contexts) {
-        const transEntry = trans.find(keyContext, keyName)
-        if (!transEntry) continue
-
-        transEntry.flag = 'unverified'
-
-        if (key.isPlural) {
-          const translations: Record<string, string> = {}
-          for (const [form, value] of Object.entries(sugg.translation)) {
-            if (value) translations[form] = value
-          }
-          if (Object.keys(translations).length > 0 && !isEqual(transEntry.messages, translations)) {
-            log.verbose('updateTransEntries', `updating ${locale} value of ${keyName} (unverified)`)
-            transEntry.messages = translations as TransMessages
-          }
-        } else {
-          const value = sugg.translation.other
-          if (value && value !== transEntry.messages.other) {
-            log.verbose('updateTransEntries', `updating ${locale} value of ${keyName} (unverified)`)
             transEntry.messages = { other: value }
           }
         }

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -130,6 +130,10 @@ function creatingSuggestionHasLocale(key: CreateL10nKeyInput, locale: string): b
   return key.suggestions?.some(s => s.locale === locale) ?? false
 }
 
+function updatingSuggestionHasLocale(key: UpdateL10nKeyInput, locale: string): boolean {
+  return key.suggestions?.some(s => s.locale === locale) ?? false
+}
+
 function createSuggestion(locale: string, isPlural: boolean, messages: TransMessages): CreateSuggestionInput {
   if (isPlural) {
     const translation: Record<string, string> = {}
@@ -292,7 +296,9 @@ export function buildKeyChanges(
             updating = { keyId: listedKey.id }
             updatingKeyMap[entryKey] = updating
           }
-          pushSuggestion(updating, createSuggestion(serverLocale, listedKey.isPlural, transEntry.messages))
+          if (!updatingSuggestionHasLocale(updating, serverLocale)) {
+            pushSuggestion(updating, createSuggestion(serverLocale, listedKey.isPlural, transEntry.messages))
+          }
         }
       } else {
         // 새 키


### PR DESCRIPTION
## Summary

- l10n-storage가 신규 `GET /keys-to-serve` 엔드포인트로 locale별 `serveSuggestions` 정책을 적용한 단일 `translations`로 응답하므로, syncer는 그대로 반영만 하면 됨
- 기존 응답의 `suggestions` 분기와 `unverified` flag 처리 코드 제거
- 업로드 시 `(key, locale)`에 이미 pending suggestion이 있는지 여부는 `keys-to-serve`가 노출하지 않으므로 storage 측 dedup에 위임 (옵션 1)
- 다운로드용 타입을 `L10nKey` → `L10nKeyToServe`로 교체 (서버 PR과 명명 통일)

## Depends on

- [ ] tpcint/tpc-agent#1053 (머지 + 배포 완료) — 신규 `keys-to-serve` 엔드포인트와 `serve_suggestions` 컬럼이 운영에 반영되어야 본 변경의 sync가 동작함

## Test plan

- [x] `npx tsc -b` 통과
- [x] `npm run lint` 통과
- [x] `npm test` 통과 (syncer-l10n-storage 11/11 포함, 전체 0 fail)
- [ ] tpc-agent #1053 배포 후 실제 sync 1회 dry-run으로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)