### PR TITLE
test(syncer-l10n-storage): add e2e tests against tpc-agent backend

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,81 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    outputs:
+      should_run: ${{ steps.filter.outputs.syncer_l10n_storage }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            syncer_l10n_storage:
+              - 'packages/syncer-l10n-storage/**'
+              - 'packages/core/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/e2e.yml'
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    # fork PR에서는 OIDC/secrets 접근이 안 되므로 동일 리포 PR에서만 실행
+    if: |
+      needs.changes.outputs.should_run == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: e2e-pr${{ github.event.number }}
+      cancel-in-progress: true
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      BACKEND_IMAGE: ${{ secrets.BACKEND_IMAGE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/299329474524/locations/global/workloadIdentityPools/github/providers/my-repo
+          service_account: ci-e2e@tpc-misc.iam.gserviceaccount.com
+
+      - run: gcloud auth configure-docker --quiet
+
+      - name: Start tpc-agent backend
+        run: docker compose -f packages/syncer-l10n-storage/docker-compose.yml up -d --wait
+
+      - name: Setup node with cached node_modules
+        uses: ./.github/actions/setup-node-cached
+        with:
+          node-version: 22
+
+      - name: Build
+        run: npm run build
+
+      - name: Run E2E tests
+        env:
+          TPC_AGENT_URL: http://localhost:5100
+          TPC_AGENT_TOKEN: ${{ secrets.TPC_AGENT_DEV_TOKEN }}
+        run: npm run test:e2e -w l10n-tools-syncer-l10n-storage
+
+      - name: Backend logs (on failure)
+        if: failure()
+        run: docker compose -f packages/syncer-l10n-storage/docker-compose.yml logs
+
+      - name: Teardown backend
+        if: always()
+        run: docker compose -f packages/syncer-l10n-storage/docker-compose.yml down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,8 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     outputs:
       should_run: ${{ steps.filter.outputs.syncer_l10n_storage }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .superset/
 node_modules/
 dist/
+.env
+.env.local

--- a/packages/syncer-l10n-storage/.env.example
+++ b/packages/syncer-l10n-storage/.env.example
@@ -1,0 +1,5 @@
+# tpc-agent backend image (required for docker-compose and e2e)
+BACKEND_IMAGE=
+
+# Dev token for local tpc-agent backend (required for e2e)
+TPC_AGENT_TOKEN=

--- a/packages/syncer-l10n-storage/docker-compose.yml
+++ b/packages/syncer-l10n-storage/docker-compose.yml
@@ -1,0 +1,71 @@
+x-backend-image: &backend-image
+  image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required (see .env.example)}
+
+services:
+  postgres:
+    image: postgres:18-alpine
+    command: ["postgres", "-c", "port=5434"]
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: devdb
+    ports:
+      - "5100:5100"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test -d devdb -p 5434"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  copy-migrations:
+    <<: *backend-image
+    entrypoint: ["sh", "-c", "mkdir -p /shared/migrations && cp tools/initdb/migrations/*.sql /shared/migrations/ && ls /shared/migrations/"]
+    volumes:
+      - migrations:/shared
+
+  migrate:
+    image: postgres:18-alpine
+    environment:
+      PGHOST: postgres
+      PGPORT: "5434"
+      PGUSER: test
+      PGPASSWORD: test
+      PGDATABASE: devdb
+    entrypoint:
+      - sh
+      - -ec
+      - |
+        for f in /shared/migrations/*.sql; do
+          case "$$(basename "$$f")" in *_rollback.sql) continue;; esac
+          echo "Applying: $$f"
+          psql -f "$$f"
+        done
+    volumes:
+      - migrations:/shared
+    depends_on:
+      postgres:
+        condition: service_healthy
+      copy-migrations:
+        condition: service_completed_successfully
+
+  app:
+    <<: *backend-image
+    network_mode: service:postgres
+    environment:
+      NODE_ENV: development
+      STAGE: sandbox
+      PORT: 5100
+      USE_LOCAL_RESOURCES: "true"
+      GOOGLE_CLOUD_PROJECT: tpc-misc
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:5100/api/test/info || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+      start_period: 15s
+
+volumes:
+  migrations:

--- a/packages/syncer-l10n-storage/package.json
+++ b/packages/syncer-l10n-storage/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "tsx --conditions source --test \"src/**/*.test.ts\""
+    "test": "tsx --conditions source --test \"src/*.test.ts\"",
+    "test:e2e": "tsx --env-file-if-exists=.env --conditions source --test \"src/e2e/*.e2e.test.ts\""
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/syncer-l10n-storage/src/e2e/helpers.ts
+++ b/packages/syncer-l10n-storage/src/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import { DomainConfig, L10nConfig } from 'l10n-tools-core'
+import type { CreateL10nKeyInput, L10nKeyMetadata, L10nKeyTag } from '../api-types.js'
 
 export const API_BASE = process.env.TPC_AGENT_URL ?? 'http://localhost:5100'
 
@@ -93,4 +94,32 @@ export function buildDomainConfig(): DomainConfig {
     locales: [],
     outputs: [],
   })
+}
+
+interface SeededKey {
+  id: string,
+  keyName: string,
+  isPlural: boolean,
+  tags: L10nKeyTag[],
+  metadata: L10nKeyMetadata[],
+  suggestions: { id: string, locale: string }[],
+}
+
+export async function seedKeys(projectId: string, keys: CreateL10nKeyInput[]): Promise<SeededKey[]> {
+  await api(`/projects/${projectId}/keys`, {
+    method: 'POST',
+    body: JSON.stringify({ keys }),
+  })
+  const response = await api<{ keys: SeededKey[] }>(
+    `/projects/${projectId}/keys?includeSuggestions=1`,
+  )
+  return response.keys
+}
+
+export async function acceptAllSuggestions(seeded: SeededKey[]): Promise<void> {
+  for (const k of seeded) {
+    for (const s of k.suggestions) {
+      await api(`/suggestions/${s.id}/accept`, { method: 'POST' })
+    }
+  }
 }

--- a/packages/syncer-l10n-storage/src/e2e/helpers.ts
+++ b/packages/syncer-l10n-storage/src/e2e/helpers.ts
@@ -1,0 +1,96 @@
+import { DomainConfig, L10nConfig } from 'l10n-tools-core'
+
+export const API_BASE = process.env.TPC_AGENT_URL ?? 'http://localhost:5100'
+
+function requireToken(): string {
+  const token = process.env.TPC_AGENT_TOKEN
+  if (!token) {
+    throw new Error('TPC_AGENT_TOKEN env var is required for e2e tests (see packages/syncer-l10n-storage/.env.example)')
+  }
+  return token
+}
+
+export const DEV_TOKEN = requireToken()
+
+export async function api<T = unknown>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}/api/l10n${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${DEV_TOKEN}`,
+      ...options?.headers,
+    },
+  })
+  if (!res.ok && res.status !== 204) {
+    const body = await res.text()
+    throw new Error(`API ${path} failed: ${res.status} ${body}`)
+  }
+  if (res.status === 204) return undefined as T
+  return await res.json() as T
+}
+
+export async function isL10nApiAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/l10n/locales`, {
+      headers: { Authorization: `Bearer ${DEV_TOKEN}` },
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export interface CreatedProject {
+  projectId: string,
+  projectName: string,
+}
+
+export async function createProject(namePrefix: string, locales: string[], sourceLocale = 'en'): Promise<CreatedProject> {
+  const projectName = `${namePrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const { project } = await api<{ project: { id: string } }>('/projects', {
+    method: 'POST',
+    body: JSON.stringify({ name: projectName, sourceLocale }),
+  })
+  const projectId = project.id
+
+  await api(`/projects/${projectId}/locales`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      locales: locales.map(locale => ({ locale, assignees: [] })),
+    }),
+  })
+
+  return { projectId, projectName }
+}
+
+export async function deleteProject(projectId: string | undefined): Promise<void> {
+  if (!projectId) return
+  await api(`/projects/${projectId}`, { method: 'DELETE' }).catch(() => {})
+}
+
+export function buildL10nConfig(projectId: string, opts?: {
+  source?: string,
+  localeSyncMap?: { [locale: string]: string },
+}): L10nConfig {
+  return new L10nConfig({
+    'domains': {
+      app: { type: 'typescript', tag: 'web', locales: [], outputs: [] },
+    },
+    'sync-target': 'l10n-storage',
+    'l10n-storage': {
+      'url': API_BASE,
+      projectId,
+      'source': opts?.source,
+      'locale-sync-map': opts?.localeSyncMap,
+    },
+  })
+}
+
+export function buildDomainConfig(): DomainConfig {
+  return new DomainConfig({
+    type: 'typescript',
+    tag: 'web',
+    locales: [],
+    outputs: [],
+  })
+}

--- a/packages/syncer-l10n-storage/src/e2e/helpers.ts
+++ b/packages/syncer-l10n-storage/src/e2e/helpers.ts
@@ -66,7 +66,9 @@ export async function createProject(namePrefix: string, locales: string[], sourc
 
 export async function deleteProject(projectId: string | undefined): Promise<void> {
   if (!projectId) return
-  await api(`/projects/${projectId}`, { method: 'DELETE' }).catch(() => {})
+  await api(`/projects/${projectId}`, { method: 'DELETE' }).catch((err: unknown) => {
+    console.warn(`failed to delete e2e project ${projectId}:`, err)
+  })
 }
 
 export function buildL10nConfig(projectId: string, opts?: {

--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -5,6 +5,7 @@ import { L10nStorageApiClient } from '../api-client.js'
 import type { L10nKeyToServe } from '../api-types.js'
 import { syncTransToL10nStorage } from '../l10n-storage.js'
 import {
+  acceptAllSuggestions,
   API_BASE,
   buildDomainConfig,
   buildL10nConfig,
@@ -12,6 +13,7 @@ import {
   deleteProject,
   DEV_TOKEN,
   isL10nApiAvailable,
+  seedKeys,
 } from './helpers.js'
 
 function key(k: string, opts?: { isPlural?: boolean, context?: string | null }): KeyEntry {
@@ -88,17 +90,10 @@ describe('syncTransToL10nStorage (e2e)', () => {
   })
 
   it('adds tag to existing key without duplicating', async () => {
-    const apiBefore = await fetch(`${API_BASE}/api/l10n/projects/${projectId}/keys`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${DEV_TOKEN}` },
-      body: JSON.stringify({
-        keys: [{
-          keyName: 'shared.key',
-          tags: [{ tag: 'web', source: 'other' }],
-        }],
-      }),
-    })
-    assert.ok(apiBefore.ok, `seed failed: ${apiBefore.status}`)
+    await seedKeys(projectId!, [{
+      keyName: 'shared.key',
+      tags: [{ tag: 'web', source: 'other' }],
+    }])
 
     const config = buildL10nConfig(projectId!, { source: 'main' })
     await syncTransToL10nStorage(
@@ -113,35 +108,15 @@ describe('syncTransToL10nStorage (e2e)', () => {
   })
 
   it('downloads server translations into local trans entries', async () => {
-    const seed = await fetch(`${API_BASE}/api/l10n/projects/${projectId}/keys`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${DEV_TOKEN}` },
-      body: JSON.stringify({
-        keys: [{
-          keyName: 'server.has.translation',
-          tags: [{ tag: 'web', source: 'main' }],
-          suggestions: [
-            { locale: 'en', translation: { other: 'Server EN' }, suggestedBy: 'syncer' },
-            { locale: 'ko', translation: { other: '서버 번역' }, suggestedBy: 'syncer' },
-          ],
-        }],
-      }),
-    })
-    assert.ok(seed.ok, `seed failed: ${seed.status}`)
-
-    const { keys: createdKeys } = await (await fetch(
-      `${API_BASE}/api/l10n/projects/${projectId}/keys?includeSuggestions=1`,
-      { headers: { Authorization: `Bearer ${DEV_TOKEN}` } },
-    )).json() as { keys: { id: string, keyName: string, suggestions: { id: string, locale: string }[] }[] }
-    for (const k of createdKeys) {
-      for (const s of k.suggestions) {
-        const acc = await fetch(`${API_BASE}/api/l10n/suggestions/${s.id}/accept`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${DEV_TOKEN}` },
-        })
-        assert.ok(acc.ok, `accept failed: ${acc.status}`)
-      }
-    }
+    const seeded = await seedKeys(projectId!, [{
+      keyName: 'server.has.translation',
+      tags: [{ tag: 'web', source: 'main' }],
+      suggestions: [
+        { locale: 'en', translation: { other: 'Server EN' }, suggestedBy: 'syncer' },
+        { locale: 'ko', translation: { other: '서버 번역' }, suggestedBy: 'syncer' },
+      ],
+    }])
+    await acceptAllSuggestions(seeded)
 
     const localTrans = {
       en: [trans('server.has.translation', { other: '' })],
@@ -192,5 +167,136 @@ describe('syncTransToL10nStorage (e2e)', () => {
     const mapped = created.find(x => x.keyName === 'mapped.key')!
     const locales = mapped.suggestions.map(s => s.locale).sort()
     assert.deepEqual(locales, ['en', 'ko'])
+  })
+
+  it('removes context from metadata when local entry no longer has it', async () => {
+    await seedKeys(projectId!, [{
+      keyName: 'ctx.key',
+      tags: [{ tag: 'web', source: 'main' }],
+      metadata: [{ tag: 'web', metaKey: 'context', metaValue: JSON.stringify(['ctx-A', 'ctx-B']) }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    // ctx-A만 로컬에 남고 ctx-B는 사라진 상태
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('ctx.key', { context: 'ctx-A' })], {}, false,
+    )
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    const ctxMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'context')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['ctx-A'])
+    assert.equal(k.tags.length, 1, 'tag remains because ctx-A still belongs to main')
+  })
+
+  it('removes own-source tag when all contexts are gone', async () => {
+    await seedKeys(projectId!, [{
+      keyName: 'ctx.gone.key',
+      tags: [{ tag: 'web', source: 'main' }, { tag: 'web', source: 'other' }],
+      metadata: [{ tag: 'web', metaKey: 'context', metaValue: JSON.stringify(['ctx-only']) }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    // 로컬엔 더 이상 ctx-only가 없음 → main source 태그가 빠져야 함
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [], {}, false,
+    )
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    assert.ok(!k.tags.some(t => t.source === 'main'), 'main source tag removed')
+    assert.ok(k.tags.some(t => t.source === 'other'), 'other source tag preserved')
+    const ctxMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'context')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), [])
+  })
+
+  it('attaches additionalTags + globalMetadata + tagMetadata when creating keys', async () => {
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('extra.key')], { en: [trans('extra.key', { other: 'X' })] }, false,
+      {
+        additionalTags: ['featured'],
+        globalMetadata: { team: 'l10n' },
+        tagMetadata: { repository: 'likey-web' },
+      },
+    )
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    const tagPairs = k.tags.map(t => ({ tag: t.tag, source: t.source }))
+    assert.ok(tagPairs.some(t => t.tag === 'web' && t.source === 'main'))
+    assert.ok(tagPairs.some(t => t.tag === 'featured' && t.source === 'main'))
+    assert.ok(k.metadata.some(m => m.tag === null && m.metaKey === 'team' && m.metaValue === 'l10n'))
+    assert.ok(k.metadata.some(m => m.tag === 'web' && m.metaKey === 'repository' && m.metaValue === 'likey-web'))
+  })
+
+  it('refreshes references metadata on every sync', async () => {
+    await seedKeys(projectId!, [{
+      keyName: 'ref.key',
+      tags: [{ tag: 'web', source: 'main' }],
+      metadata: [{
+        tag: 'web',
+        metaKey: 'references',
+        metaValue: JSON.stringify([{ file: 'old.ts' }]),
+      }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    const keyEntry: KeyEntry = {
+      key: 'ref.key',
+      isPlural: false,
+      context: null,
+      references: [{ file: 'src/new.ts', loc: '10:5' }],
+      comments: [],
+    }
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web', [keyEntry], {}, false)
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    const refMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'references')
+    assert.deepEqual(JSON.parse(refMeta!.metaValue), [{ file: 'src/new.ts', loc: '10:5' }])
+  })
+
+  it('downloads plural translations as a full message object', async () => {
+    const seeded = await seedKeys(projectId!, [{
+      keyName: 'plural.download',
+      isPlural: true,
+      tags: [{ tag: 'web', source: 'main' }],
+      suggestions: [
+        { locale: 'en', translation: { one: '{n} item', other: '{n} items' }, suggestedBy: 'syncer' },
+      ],
+    }])
+    await acceptAllSuggestions(seeded)
+
+    const localTrans = {
+      en: [trans('plural.download', {})],
+    }
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('plural.download', { isPlural: true })],
+      localTrans, true,
+    )
+
+    assert.equal(localTrans.en[0].messages.one, '{n} item')
+    assert.equal(localTrans.en[0].messages.other, '{n} items')
+  })
+
+  it('clears flag on local trans entry when server translation is applied', async () => {
+    const seeded = await seedKeys(projectId!, [{
+      keyName: 'flagged.key',
+      tags: [{ tag: 'web', source: 'main' }],
+      suggestions: [
+        { locale: 'en', translation: { other: 'Authoritative' }, suggestedBy: 'syncer' },
+      ],
+    }])
+    await acceptAllSuggestions(seeded)
+
+    const localTrans = {
+      en: [trans('flagged.key', { other: 'Authoritative' }) as TransEntry],
+    }
+    localTrans.en[0].flag = 'fuzzy'
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('flagged.key')], localTrans, true,
+    )
+
+    assert.equal(localTrans.en[0].flag, null)
   })
 })

--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -1,0 +1,196 @@
+import { after, before, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { KeyEntry, TransEntry } from 'l10n-tools-core'
+import { L10nStorageApiClient } from '../api-client.js'
+import type { L10nKeyToServe } from '../api-types.js'
+import { syncTransToL10nStorage } from '../l10n-storage.js'
+import {
+  API_BASE,
+  buildDomainConfig,
+  buildL10nConfig,
+  createProject,
+  deleteProject,
+  DEV_TOKEN,
+  isL10nApiAvailable,
+} from './helpers.js'
+
+function key(k: string, opts?: { isPlural?: boolean, context?: string | null }): KeyEntry {
+  return {
+    key: k,
+    isPlural: opts?.isPlural ?? false,
+    context: opts?.context ?? null,
+    references: [],
+    comments: [],
+  }
+}
+
+function trans(k: string, messages: Record<string, string>, opts?: { context?: string | null }): TransEntry {
+  return {
+    key: k,
+    context: opts?.context ?? null,
+    messages,
+    flag: null,
+  }
+}
+
+function findKey(keys: L10nKeyToServe[], keyName: string): L10nKeyToServe {
+  const k = keys.find(x => x.keyName === keyName)
+  if (!k) throw new Error(`key not found: ${keyName}`)
+  return k
+}
+
+describe('syncTransToL10nStorage (e2e)', () => {
+  let apiClient: L10nStorageApiClient
+  let projectId: string | undefined
+
+  before(async () => {
+    if (!await isL10nApiAvailable()) {
+      throw new Error(
+        `tpc-agent l10n API not available at ${API_BASE}. ` +
+        'Start it with: docker compose -f packages/syncer-l10n-storage/docker-compose.yml up -d --wait',
+      )
+    }
+    process.env.TPC_AGENT_TOKEN = DEV_TOKEN
+    apiClient = new L10nStorageApiClient(API_BASE, DEV_TOKEN)
+  })
+
+  beforeEach(async () => {
+    await deleteProject(projectId)
+    const created = await createProject('syncer-e2e', ['en', 'ko', 'ja'], 'en')
+    projectId = created.projectId
+  })
+
+  after(async () => {
+    await deleteProject(projectId)
+  })
+
+  it('creates new keys with suggestions on empty project', async () => {
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    const keyEntries = [key('greeting.hello'), key('greeting.bye')]
+    const allTransData = {
+      en: [trans('greeting.hello', { other: 'Hello' }), trans('greeting.bye', { other: 'Bye' })],
+      ko: [trans('greeting.hello', { other: '안녕' })],
+    }
+
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web', keyEntries, allTransData, false)
+
+    const keys = await apiClient.listAllKeysToServe(projectId!)
+    assert.equal(keys.length, 2)
+
+    const tagPair = (k: L10nKeyToServe) => k.tags.map(t => ({ tag: t.tag, source: t.source }))
+
+    const hello = findKey(keys, 'greeting.hello')
+    assert.deepEqual(tagPair(hello), [{ tag: 'web', source: 'main' }])
+    assert.equal(hello.isPlural, false)
+
+    const bye = findKey(keys, 'greeting.bye')
+    assert.deepEqual(tagPair(bye), [{ tag: 'web', source: 'main' }])
+  })
+
+  it('adds tag to existing key without duplicating', async () => {
+    const apiBefore = await fetch(`${API_BASE}/api/l10n/projects/${projectId}/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${DEV_TOKEN}` },
+      body: JSON.stringify({
+        keys: [{
+          keyName: 'shared.key',
+          tags: [{ tag: 'web', source: 'other' }],
+        }],
+      }),
+    })
+    assert.ok(apiBefore.ok, `seed failed: ${apiBefore.status}`)
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('shared.key')], { en: [] }, false,
+    )
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    // 같은 tag가 다른 source로 이미 있으면 syncer는 태그를 또 붙이지 않는다.
+    assert.equal(k.tags.length, 1)
+    assert.equal(k.tags[0].tag, 'web')
+    assert.equal(k.tags[0].source, 'other')
+  })
+
+  it('downloads server translations into local trans entries', async () => {
+    const seed = await fetch(`${API_BASE}/api/l10n/projects/${projectId}/keys`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${DEV_TOKEN}` },
+      body: JSON.stringify({
+        keys: [{
+          keyName: 'server.has.translation',
+          tags: [{ tag: 'web', source: 'main' }],
+          suggestions: [
+            { locale: 'en', translation: { other: 'Server EN' }, suggestedBy: 'syncer' },
+            { locale: 'ko', translation: { other: '서버 번역' }, suggestedBy: 'syncer' },
+          ],
+        }],
+      }),
+    })
+    assert.ok(seed.ok, `seed failed: ${seed.status}`)
+
+    const { keys: createdKeys } = await (await fetch(
+      `${API_BASE}/api/l10n/projects/${projectId}/keys?includeSuggestions=1`,
+      { headers: { Authorization: `Bearer ${DEV_TOKEN}` } },
+    )).json() as { keys: { id: string, keyName: string, suggestions: { id: string, locale: string }[] }[] }
+    for (const k of createdKeys) {
+      for (const s of k.suggestions) {
+        const acc = await fetch(`${API_BASE}/api/l10n/suggestions/${s.id}/accept`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${DEV_TOKEN}` },
+        })
+        assert.ok(acc.ok, `accept failed: ${acc.status}`)
+      }
+    }
+
+    const localTrans = {
+      en: [trans('server.has.translation', { other: '' })],
+      ko: [trans('server.has.translation', { other: '' })],
+    }
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web', [key('server.has.translation')],
+      localTrans, true, // skipUpload — 다운로드만 검증
+    )
+
+    assert.equal(localTrans.en[0].messages.other, 'Server EN')
+    assert.equal(localTrans.ko[0].messages.other, '서버 번역')
+  })
+
+  it('creates a plural key with plural suggestions', async () => {
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    const keyEntries = [key('items.count', { isPlural: true })]
+    const allTransData = {
+      en: [trans('items.count', { one: '{count} item', other: '{count} items' })],
+    }
+
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web', keyEntries, allTransData, false)
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    assert.equal(k.keyName, 'items.count')
+    assert.equal(k.isPlural, true)
+  })
+
+  it('respects locale-sync-map when uploading suggestions', async () => {
+    const config = buildL10nConfig(projectId!, {
+      source: 'main',
+      localeSyncMap: { 'ko-KR': 'ko' },
+    })
+    const keyEntries = [key('mapped.key')]
+    const allTransData = {
+      'en': [trans('mapped.key', { other: 'Mapped' })],
+      'ko-KR': [trans('mapped.key', { other: '매핑됨' })],
+    }
+
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web', keyEntries, allTransData, false)
+
+    const { keys: created } = await (await fetch(
+      `${API_BASE}/api/l10n/projects/${projectId}/keys?includeSuggestions=1`,
+      { headers: { Authorization: `Bearer ${DEV_TOKEN}` } },
+    )).json() as { keys: { keyName: string, suggestions: { locale: string }[] }[] }
+
+    const mapped = created.find(x => x.keyName === 'mapped.key')!
+    const locales = mapped.suggestions.map(s => s.locale).sort()
+    assert.deepEqual(locales, ['en', 'ko'])
+  })
+})


### PR DESCRIPTION
## Summary
- syncer-l10n-storage 패키지에 tpc-agent 백엔드 대상으로 도는 e2e 테스트 추가 (`src/e2e/`).
- 패키지별 `docker-compose.yml`로 tpc-agent + postgres + migrate 스택을 띄우고, `syncTransToL10nStorage`가 실제 keys-to-serve API와 어떻게 상호작용하는지 검증.
- 새 워크플로 `e2e.yml`이 동일 리포 PR에서만 동작하도록 fork 가드 적용. private 백엔드 이미지 경로와 dev token은 secret으로 분리 (`BACKEND_IMAGE`, `TPC_AGENT_DEV_TOKEN`).
- 단위 테스트(`src/*.test.ts`)와 e2e(`src/e2e/*.e2e.test.ts`)는 별도 npm script (`test`, `test:e2e`)로 분리.

## Test plan
- [ ] PR CI: e2e 워크플로가 통과
- [x] 로컬에서 `docker compose -f packages/syncer-l10n-storage/docker-compose.yml up -d --wait` 후 `npm run test:e2e -w l10n-tools-syncer-l10n-storage` 5/5 통과
- [x] 기본 `npm test` (단위 테스트만) 영향 없음
- [x] `npm run lint`, `npm run build` 통과

## 로컬 실행
1. `cp packages/syncer-l10n-storage/.env.example packages/syncer-l10n-storage/.env` 후 값 채우기
2. `cd packages/syncer-l10n-storage && docker compose up -d --wait`
3. `npm run test:e2e -w l10n-tools-syncer-l10n-storage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)