### PR TITLE
ci: inline BACKEND_IMAGE to fix Dependabot e2e runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
       id-token: write
 
     env:
-      BACKEND_IMAGE: ${{ secrets.BACKEND_IMAGE }}
+      BACKEND_IMAGE: gcr.io/tpc-misc/tpc-misc-tpc-agent:sandbox
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Dependabot PR에서 e2e가 모두 실패하던 원인 수정
- `secrets.BACKEND_IMAGE`는 Dependabot 컨텍스트에서 빈 값으로 떨어져 docker-compose의 `\${BACKEND_IMAGE:?...}` 가드에서 실패함
- 이미지 경로는 민감 정보가 아니므로 `e2e.yml`에 sandbox 태그(`gcr.io/tpc-misc/tpc-misc-tpc-agent:sandbox`)를 인라인

## Notes

- 머지 후 더 이상 사용되지 않는 `BACKEND_IMAGE` actions secret은 별도로 제거 가능
- 이미지 pull 자격은 기존대로 WIF로 인증한 `ci-e2e@tpc-misc.iam.gserviceaccount.com`이 담당

## Test plan

- [ ] 이 PR 자체의 E2E Tests 잡이 그린인지 확인
- [ ] 이후 Dependabot PR 한 건에서 e2e가 더 이상 BACKEND_IMAGE 미설정으로 실패하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)