### PR TITLE
revert: inline BACKEND_IMAGE (#313)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
       id-token: write
 
     env:
-      BACKEND_IMAGE: gcr.io/tpc-misc/tpc-misc-tpc-agent:sandbox
+      BACKEND_IMAGE: ${{ secrets.BACKEND_IMAGE }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- #313 revert
- l10n-tools 리포는 public이고 tpc-agent backend 이미지 경로는 사내 정보라 인라인 노출하지 않기로 결정
- 대신 \`BACKEND_IMAGE\`/\`TPC_AGENT_DEV_TOKEN\`을 Dependabot scope secret으로도 등록해서 Dependabot PR에서도 e2e가 통과하도록 처리 (별도 secret 등록은 본 PR과 무관하게 진행)

## Test plan

- [ ] BACKEND_IMAGE secret 재등록 후 이 PR의 E2E Tests 잡이 그린인지 확인
- [ ] 이후 Dependabot PR에서 e2e가 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)