### PR TITLE
ci: bump release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `googleapis/release-please-action`을 v4 → v5로 업그레이드
- v5는 액션 내부 런타임을 node24로 올린 것이 주요 변경 (입력 파라미터 호환)
- 내부 `release-please` 라이브러리 17.3.0 → 17.6.0 함께 반영됨

## Test plan
- [ ] main 머지 후 다음 release-please 워크플로우 실행이 정상적으로 release PR을 생성/업데이트하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)