### PR TITLE
feat: add --source filter to check and _compile

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -12,10 +12,12 @@ import {
   getKeysPath,
   getTransPath,
   L10nConfig,
+  materializeSnapshotsToTempDir,
   pluginRegistry,
   type ProgramOptions,
   readKeyEntries,
   readTransEntries,
+  type SyncerKeySnapshot,
   type SyncerOptions,
   syncTransToTarget,
   updateTrans,
@@ -45,6 +47,21 @@ function buildSyncerOptions(opts: { tags?: string, metadata?: Record<string, str
     tagMetadata: opts.tagMetadata && Object.keys(opts.tagMetadata).length > 0 ? opts.tagMetadata : undefined,
     source: opts.source,
   }
+}
+
+async function fetchSourceSnapshots(
+  cmdName: string,
+  config: L10nConfig,
+  domainConfig: DomainConfig,
+  source: string,
+): Promise<SyncerKeySnapshot[]> {
+  const syncTarget = config.getSyncTarget()
+  const sourceFilter = pluginRegistry.getSourceFilter(syncTarget)
+  if (!sourceFilter) {
+    log.error(cmdName, `--source is not supported by sync target '${syncTarget}'`)
+    process.exit(1)
+  }
+  return await sourceFilter(config, domainConfig, domainConfig.getTag(), source)
 }
 
 /**
@@ -234,19 +251,32 @@ async function run() {
           const contextSet = opts.contexts !== undefined
             ? new Set<string>(opts.contexts.split(',').filter(Boolean))
             : null
+          const sourceKeyNameSet = opts.source
+            ? new Set((await fetchSourceSnapshots(cmd.name(), config, domainConfig, opts.source)).map(s => s.keyName))
+            : null
 
-          if (fileSet.size === 0 && contextSet == null) {
+          if (fileSet.size === 0 && contextSet == null && sourceKeyNameSet == null) {
             return null
           }
 
+          const fileOrContextActive = fileSet.size > 0 || contextSet != null
           const keyEntries = (await readKeyEntries(keysPath))
             .filter(keyEntry => {
+              if (sourceKeyNameSet != null && !sourceKeyNameSet.has(keyEntry.key)) {
+                return false
+              }
+              if (!fileOrContextActive) {
+                return true
+              }
               const matchesFile = fileSet.size > 0
                 && keyEntry.references.some(ref => fileSet.has(ref.file))
               const matchesContext = contextSet != null
                 && keyEntry.context != null && contextSet.has(keyEntry.context)
               return matchesFile || matchesContext
             })
+          if (sourceKeyNameSet != null && keyEntries.length === 0) {
+            log.warn(cmd.name(), `no local keys matched source '${opts.source}' (run 'l10n update' or 'l10n sync' to refresh local keys)`)
+          }
           return EntryCollection.loadEntries(keyEntries)
         })()
         for (const locale of locales) {
@@ -392,10 +422,24 @@ async function run() {
       })
     })
 
+  type CompileOptions = {
+    source?: string,
+  }
   program.command('_compile')
     .description('Write domain asset from translations (internal use only)')
-    .action(async (opts, cmd: Command) => {
+    .option('--source <source>', 'compile only keys belonging to this source (l10n-storage only)')
+    .action(async (opts: CompileOptions, cmd: Command) => {
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
+        if (opts.source) {
+          const snapshots = await fetchSourceSnapshots(cmd.name(), config, domainConfig, opts.source)
+          const tempDir = await materializeSnapshotsToTempDir(domainName, snapshots, domainConfig.getLocales())
+          try {
+            await compileAll(domainName, domainConfig, tempDir)
+          } finally {
+            await fsp.rm(tempDir, { recursive: true, force: true })
+          }
+          return
+        }
         const cacheDir = domainConfig.getCacheDir()
         const transDir = path.join(cacheDir, domainName)
         await compileAll(domainName, domainConfig, transDir)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   SyncerPlugin,
   SyncerFunc,
   SyncerOptions,
+  SyncerKeySnapshot,
+  SyncerSourceFilterFunc,
 } from './plugin-types.js'
 
 export { pluginRegistry } from './plugin-registry.js'
@@ -33,6 +35,7 @@ export {
   type KeyEntry,
   type TransEntry,
   type TransMessages,
+  type TransPluralKey,
   type KeyReference,
   readKeyEntries,
   readTransEntries,
@@ -66,3 +69,4 @@ export { updateTrans, getSrcPaths } from './common.js'
 export { extractKeys } from './extractor.js'
 export { compileAll } from './compiler.js'
 export { syncTransToTarget } from './syncer.js'
+export { materializeSnapshotsToTempDir } from './source-filter.js'

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -1,7 +1,14 @@
 import { pathToFileURL } from 'node:url'
 import path from 'node:path'
 import log from 'npmlog'
-import type { CompilerFunc, ExtractorFunc, L10nPlugin, PluginFactory, SyncerFunc } from './plugin-types.js'
+import type {
+  CompilerFunc,
+  ExtractorFunc,
+  L10nPlugin,
+  PluginFactory,
+  SyncerFunc,
+  SyncerSourceFilterFunc,
+} from './plugin-types.js'
 
 /**
  * Known plugin packages for auto-discovery
@@ -65,6 +72,7 @@ export class PluginRegistry {
   private extractors = new Map<string, ExtractorFunc>()
   private compilers = new Map<string, CompilerFunc>()
   private syncers = new Map<string, SyncerFunc>()
+  private sourceFilters = new Map<string, SyncerSourceFilterFunc>()
   private initialized = false
   private initPromise: Promise<void> | null = null
 
@@ -178,6 +186,9 @@ export class PluginRegistry {
         log.warn('plugin-registry', `Syncer for ${sync.syncTarget} already registered, overwriting`)
       }
       this.syncers.set(sync.syncTarget, sync.syncer)
+      if (sync.sourceFilter) {
+        this.sourceFilters.set(sync.syncTarget, sync.sourceFilter)
+      }
     }
   }
 
@@ -200,6 +211,13 @@ export class PluginRegistry {
    */
   getSyncer(syncTarget: string): SyncerFunc | undefined {
     return this.syncers.get(syncTarget)
+  }
+
+  /**
+   * Get a source filter for a sync target (optional capability)
+   */
+  getSourceFilter(syncTarget: string): SyncerSourceFilterFunc | undefined {
+    return this.sourceFilters.get(syncTarget)
   }
 
   /**

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -1,5 +1,5 @@
 import type { CompilerConfig, DomainConfig, L10nConfig } from './config.js'
-import type { KeyEntry, TransEntry } from './entry.js'
+import type { KeyEntry, TransEntry, TransMessages } from './entry.js'
 
 /**
  * Extractor function signature
@@ -70,6 +70,32 @@ export type SyncerFunc = (
 ) => Promise<void>
 
 /**
+ * Snapshot of a key fetched from the sync target, used by source-filtering features
+ * (e.g., `check --source` and `_compile --source`). Locale codes are local-side
+ * (after applying any locale sync map).
+ */
+export interface SyncerKeySnapshot {
+  keyName: string,
+  isPlural: boolean,
+  /** Contexts the key is associated with under this tag. Always at least one entry. */
+  contexts: (string | null)[],
+  /** Translations keyed by local locale code. */
+  translations: { [locale: string]: TransMessages },
+}
+
+/**
+ * Optional capability: fetch keys narrowed by tag (and optionally source).
+ * Implemented by syncers whose backend supports source/tag-based filtering
+ * (currently l10n-storage).
+ */
+export type SyncerSourceFilterFunc = (
+  config: L10nConfig,
+  domainConfig: DomainConfig,
+  tag: string,
+  source: string | undefined,
+) => Promise<SyncerKeySnapshot[]>
+
+/**
  * Syncer plugin definition
  */
 export interface SyncerPlugin {
@@ -77,6 +103,8 @@ export interface SyncerPlugin {
   syncTarget: string,
   /** The syncer function */
   syncer: SyncerFunc,
+  /** Optional: fetch keys narrowed by (tag, source). */
+  sourceFilter?: SyncerSourceFilterFunc,
 }
 
 /**

--- a/packages/core/src/source-filter.test.ts
+++ b/packages/core/src/source-filter.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { readTransEntries } from './entry.js'
+import type { SyncerKeySnapshot } from './plugin-types.js'
+import { materializeSnapshotsToTempDir } from './source-filter.js'
+
+function makeSnapshot(overrides: Partial<SyncerKeySnapshot> & { keyName: string }): SyncerKeySnapshot {
+  return {
+    keyName: overrides.keyName,
+    isPlural: overrides.isPlural ?? false,
+    contexts: overrides.contexts ?? [null],
+    translations: overrides.translations ?? {},
+  }
+}
+
+describe('materializeSnapshotsToTempDir', () => {
+  it('writes one trans-{locale}.json per requested locale', async () => {
+    const snapshots: SyncerKeySnapshot[] = [
+      makeSnapshot({ keyName: 'hi', translations: { ko: { other: '안녕' }, en: { other: 'hi' } } }),
+    ]
+    const tempDir = await materializeSnapshotsToTempDir('domain', snapshots, ['ko', 'en'])
+    try {
+      const files = (await fsp.readdir(tempDir)).sort()
+      assert.deepEqual(files, ['trans-en.json', 'trans-ko.json'])
+
+      const ko = await readTransEntries(path.join(tempDir, 'trans-ko.json'))
+      assert.equal(ko.length, 1)
+      assert.equal(ko[0].key, 'hi')
+      assert.equal(ko[0].context, null)
+      assert.deepEqual(ko[0].messages, { other: '안녕' })
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('expands a snapshot into one entry per context', async () => {
+    const snapshots: SyncerKeySnapshot[] = [
+      makeSnapshot({
+        keyName: 'k',
+        contexts: ['ctx1', 'ctx2'],
+        translations: { ko: { other: '값' } },
+      }),
+    ]
+    const tempDir = await materializeSnapshotsToTempDir('domain', snapshots, ['ko'])
+    try {
+      const ko = await readTransEntries(path.join(tempDir, 'trans-ko.json'))
+      assert.equal(ko.length, 2)
+      const contexts = ko.map(e => e.context).sort()
+      assert.deepEqual(contexts, ['ctx1', 'ctx2'])
+      for (const entry of ko) {
+        assert.deepEqual(entry.messages, { other: '값' })
+      }
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes empty messages for locales missing in the snapshot', async () => {
+    const snapshots: SyncerKeySnapshot[] = [
+      makeSnapshot({ keyName: 'hi', translations: { ko: { other: '안녕' } } }),
+    ]
+    const tempDir = await materializeSnapshotsToTempDir('domain', snapshots, ['ko', 'en'])
+    try {
+      const en = await readTransEntries(path.join(tempDir, 'trans-en.json'))
+      assert.equal(en.length, 1)
+      assert.deepEqual(en[0].messages, {})
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('treats empty contexts array as a single null context', async () => {
+    const snapshots: SyncerKeySnapshot[] = [
+      makeSnapshot({ keyName: 'k', contexts: [], translations: { ko: { other: 'x' } } }),
+    ]
+    const tempDir = await materializeSnapshotsToTempDir('domain', snapshots, ['ko'])
+    try {
+      const ko = await readTransEntries(path.join(tempDir, 'trans-ko.json'))
+      assert.equal(ko.length, 1)
+      assert.equal(ko[0].context, null)
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/core/src/source-filter.ts
+++ b/packages/core/src/source-filter.ts
@@ -16,8 +16,10 @@ export async function materializeSnapshotsToTempDir(
   snapshots: SyncerKeySnapshot[],
   locales: string[],
 ): Promise<string> {
-  const tempDir = path.join(getTempDir(), `compile-source-${Date.now()}-${domainName}`)
-  await fsp.mkdir(tempDir, { recursive: true })
+  const safeDomain = domainName.replace(/[^a-zA-Z0-9._-]+/g, '_')
+  const baseDir = getTempDir()
+  await fsp.mkdir(baseDir, { recursive: true })
+  const tempDir = await fsp.mkdtemp(path.join(baseDir, `compile-source-${safeDomain}-`))
 
   for (const locale of locales) {
     const entries: TransEntry[] = []

--- a/packages/core/src/source-filter.ts
+++ b/packages/core/src/source-filter.ts
@@ -1,0 +1,40 @@
+import fsp from 'node:fs/promises'
+import path from 'node:path'
+import { type TransEntry, writeTransEntries } from './entry.js'
+import type { SyncerKeySnapshot } from './plugin-types.js'
+import { getTempDir, getTransPath } from './utils.js'
+
+/**
+ * Write trans-{locale}.json files representing the given snapshots into a fresh
+ * temp directory and return its path. Used by `_compile --source` to compile a
+ * subset of keys without mutating the local cache.
+ *
+ * Caller is responsible for cleaning up the returned directory.
+ */
+export async function materializeSnapshotsToTempDir(
+  domainName: string,
+  snapshots: SyncerKeySnapshot[],
+  locales: string[],
+): Promise<string> {
+  const tempDir = path.join(getTempDir(), `compile-source-${Date.now()}-${domainName}`)
+  await fsp.mkdir(tempDir, { recursive: true })
+
+  for (const locale of locales) {
+    const entries: TransEntry[] = []
+    for (const snapshot of snapshots) {
+      const messages = snapshot.translations[locale] ?? {}
+      const contexts = snapshot.contexts.length > 0 ? snapshot.contexts : [null]
+      for (const context of contexts) {
+        entries.push({
+          context,
+          key: snapshot.keyName,
+          messages,
+          flag: null,
+        })
+      }
+    }
+    await writeTransEntries(getTransPath(tempDir, locale), entries)
+  }
+
+  return tempDir
+}

--- a/packages/syncer-l10n-storage/src/api-client.ts
+++ b/packages/syncer-l10n-storage/src/api-client.ts
@@ -62,6 +62,38 @@ export class L10nStorageApiClient {
     return allKeys
   }
 
+  async listKeysToServeByTag(
+    projectId: string,
+    tag: string,
+    source?: string,
+  ): Promise<L10nKeyToServe[]> {
+    const allKeys: L10nKeyToServe[] = []
+    let cursor: string | undefined
+    let previousCursor: string | undefined
+    const encodedTag = encodeURIComponent(tag)
+    do {
+      log.info(
+        'l10n-storage-api',
+        `listing keys (tag: ${tag}${source ? `, source: ${source}` : ''}${cursor ? `, cursor: ${cursor}` : ''})`,
+      )
+      const params = new URLSearchParams({ limit: '500' })
+      if (cursor) params.set('cursor', cursor)
+      if (source) params.set('source', source)
+      const response = await this.request<ListKeysToServeResponse>(
+        'GET',
+        `/api/l10n/projects/${projectId}/tags/${encodedTag}/keys-to-serve?${params}`,
+      )
+      allKeys.push(...response.keys)
+      previousCursor = cursor
+      cursor = response.nextCursor ?? undefined
+      if (cursor && cursor === previousCursor) {
+        throw new Error(`L10n Storage API pagination loop detected: cursor ${cursor} repeated`)
+      }
+      log.info('l10n-storage-api', `fetched ${response.keys.length} keys (total: ${allKeys.length})`)
+    } while (cursor)
+    return allKeys
+  }
+
   async createKeys(projectId: string, keys: CreateL10nKeyInput[]): Promise<void> {
     await this.request('POST', `/api/l10n/projects/${projectId}/keys`, { keys })
   }

--- a/packages/syncer-l10n-storage/src/e2e/helpers.ts
+++ b/packages/syncer-l10n-storage/src/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import { DomainConfig, L10nConfig } from 'l10n-tools-core'
+import { L10nStorageApiClient } from '../api-client.js'
 import type { CreateL10nKeyInput, L10nKeyMetadata, L10nKeyTag } from '../api-types.js'
 
 export const API_BASE = process.env.TPC_AGENT_URL ?? 'http://localhost:5100'
@@ -38,6 +39,27 @@ export async function isL10nApiAvailable(): Promise<boolean> {
     return res.ok
   } catch {
     return false
+  }
+}
+
+/**
+ * Probes whether the tag/source-scoped keys-to-serve endpoint is implemented.
+ * Creates a temporary project, calls the endpoint, and cleans up. Returns false
+ * for any failure (route not found, project not found, network error) so callers
+ * can skip the e2e suite when running against an older tpc-agent build.
+ */
+export async function isSourceFilterEndpointAvailable(): Promise<boolean> {
+  let probeProjectId: string | undefined
+  try {
+    const created = await createProject('source-filter-probe', [], 'en')
+    probeProjectId = created.projectId
+    const apiClient = new L10nStorageApiClient(API_BASE, DEV_TOKEN)
+    await apiClient.listKeysToServeByTag(probeProjectId, 'probe', undefined)
+    return true
+  } catch {
+    return false
+  } finally {
+    await deleteProject(probeProjectId)
   }
 }
 

--- a/packages/syncer-l10n-storage/src/e2e/helpers.ts
+++ b/packages/syncer-l10n-storage/src/e2e/helpers.ts
@@ -1,5 +1,4 @@
 import { DomainConfig, L10nConfig } from 'l10n-tools-core'
-import { L10nStorageApiClient } from '../api-client.js'
 import type { CreateL10nKeyInput, L10nKeyMetadata, L10nKeyTag } from '../api-types.js'
 
 export const API_BASE = process.env.TPC_AGENT_URL ?? 'http://localhost:5100'
@@ -39,27 +38,6 @@ export async function isL10nApiAvailable(): Promise<boolean> {
     return res.ok
   } catch {
     return false
-  }
-}
-
-/**
- * Probes whether the tag/source-scoped keys-to-serve endpoint is implemented.
- * Creates a temporary project, calls the endpoint, and cleans up. Returns false
- * for any failure (route not found, project not found, network error) so callers
- * can skip the e2e suite when running against an older tpc-agent build.
- */
-export async function isSourceFilterEndpointAvailable(): Promise<boolean> {
-  let probeProjectId: string | undefined
-  try {
-    const created = await createProject('source-filter-probe', [], 'en')
-    probeProjectId = created.projectId
-    const apiClient = new L10nStorageApiClient(API_BASE, DEV_TOKEN)
-    await apiClient.listKeysToServeByTag(probeProjectId, 'probe', undefined)
-    return true
-  } catch {
-    return false
-  } finally {
-    await deleteProject(probeProjectId)
   }
 }
 

--- a/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
@@ -11,10 +11,20 @@ import {
   deleteProject,
   DEV_TOKEN,
   isL10nApiAvailable,
+  isSourceFilterEndpointAvailable,
   seedKeys,
 } from './helpers.js'
 
-describe('listKeysToServeByTag (e2e)', () => {
+const apiAvailable = await isL10nApiAvailable()
+const endpointAvailable = apiAvailable ? await isSourceFilterEndpointAvailable() : false
+
+const skipReason: string | false = !apiAvailable
+  ? `tpc-agent l10n API not available at ${API_BASE}`
+  : !endpointAvailable
+      ? 'tag/source keys-to-serve endpoint not deployed in tpc-agent (run a build with the new endpoint to enable)'
+      : false
+
+describe('listKeysToServeByTag (e2e)', { skip: skipReason }, () => {
   let apiClient: L10nStorageApiClient
   let projectId: string | undefined
 
@@ -113,7 +123,7 @@ describe('listKeysToServeByTag (e2e)', () => {
   })
 })
 
-describe('sourceFilterForL10nStorage (e2e)', () => {
+describe('sourceFilterForL10nStorage (e2e)', { skip: skipReason }, () => {
   let projectId: string | undefined
 
   before(async () => {

--- a/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
@@ -1,0 +1,193 @@
+import { after, before, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { L10nStorageApiClient } from '../api-client.js'
+import { sourceFilterForL10nStorage } from '../source-filter.js'
+import {
+  acceptAllSuggestions,
+  API_BASE,
+  buildDomainConfig,
+  buildL10nConfig,
+  createProject,
+  deleteProject,
+  DEV_TOKEN,
+  isL10nApiAvailable,
+  seedKeys,
+} from './helpers.js'
+
+describe('listKeysToServeByTag (e2e)', () => {
+  let apiClient: L10nStorageApiClient
+  let projectId: string | undefined
+
+  before(async () => {
+    if (!await isL10nApiAvailable()) {
+      throw new Error(
+        `tpc-agent l10n API not available at ${API_BASE}. ` +
+        'Start it with: docker compose -f packages/syncer-l10n-storage/docker-compose.yml up -d --wait',
+      )
+    }
+    process.env.TPC_AGENT_TOKEN = DEV_TOKEN
+    apiClient = new L10nStorageApiClient(API_BASE, DEV_TOKEN)
+  })
+
+  beforeEach(async () => {
+    await deleteProject(projectId)
+    const created = await createProject('source-filter-e2e', ['en', 'ko'], 'en')
+    projectId = created.projectId
+  })
+
+  after(async () => {
+    await deleteProject(projectId)
+  })
+
+  it('returns only keys whose tags include the given tag', async () => {
+    await seedKeys(projectId!, [
+      { keyName: 'web.only', tags: [{ tag: 'web', source: 'main' }] },
+      { keyName: 'mobile.only', tags: [{ tag: 'mobile', source: 'main' }] },
+      { keyName: 'both', tags: [{ tag: 'web', source: 'main' }, { tag: 'mobile', source: 'main' }] },
+    ])
+
+    const keys = await apiClient.listKeysToServeByTag(projectId!, 'web')
+    const names = keys.map(k => k.keyName).sort()
+    assert.deepEqual(names, ['both', 'web.only'])
+  })
+
+  it('with source narrows to keys whose tag entry matches both tag and source in the same item', async () => {
+    await seedKeys(projectId!, [
+      // 'web' + 'PR-1' 페어가 같은 태그 항목으로 존재
+      { keyName: 'pr1.match', tags: [{ tag: 'web', source: 'PR-1' }] },
+      // 'web'은 다른 source, 'PR-1'은 다른 tag — 같은 항목 페어가 아님 → 매칭 X
+      {
+        keyName: 'split.pair',
+        tags: [{ tag: 'web', source: 'main' }, { tag: 'mobile', source: 'PR-1' }],
+      },
+      // 매칭 페어가 있고 다른 페어도 함께 있음 → 매칭
+      {
+        keyName: 'pair.plus.extras',
+        tags: [{ tag: 'web', source: 'PR-1' }, { tag: 'mobile', source: 'main' }],
+      },
+    ])
+
+    const keys = await apiClient.listKeysToServeByTag(projectId!, 'web', 'PR-1')
+    const names = keys.map(k => k.keyName).sort()
+    assert.deepEqual(names, ['pair.plus.extras', 'pr1.match'])
+  })
+
+  it('returns full tags array on matched keys (not narrowed by filter)', async () => {
+    await seedKeys(projectId!, [{
+      keyName: 'multi.tag.key',
+      tags: [{ tag: 'web', source: 'PR-1' }, { tag: 'mobile', source: 'main' }],
+    }])
+
+    const [k] = await apiClient.listKeysToServeByTag(projectId!, 'web', 'PR-1')
+    const pairs = k.tags.map(t => ({ tag: t.tag, source: t.source }))
+    assert.equal(k.tags.length, 2, 'response should include all tags, not just the filtered pair')
+    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'PR-1'))
+    assert.ok(pairs.some(p => p.tag === 'mobile' && p.source === 'main'))
+  })
+
+  it('returns an empty list when nothing matches', async () => {
+    await seedKeys(projectId!, [
+      { keyName: 'mobile.only', tags: [{ tag: 'mobile', source: 'main' }] },
+    ])
+    const keys = await apiClient.listKeysToServeByTag(projectId!, 'web', 'PR-X')
+    assert.deepEqual(keys, [])
+  })
+
+  it('paginates correctly when total exceeds API page size', async () => {
+    // 페이지네이션 동작 확인용으로 600개 키를 시드 (API 한계가 500)
+    const TOTAL = 600
+    const seedInput = Array.from({ length: TOTAL }, (_, i) => ({
+      keyName: `bulk.${String(i).padStart(4, '0')}`,
+      tags: [{ tag: 'web', source: 'PR-bulk' }],
+    }))
+    // seedKeys 한 번에 너무 많으면 서버가 거부할 수 있어 청크로 나눔
+    for (let i = 0; i < seedInput.length; i += 200) {
+      await seedKeys(projectId!, seedInput.slice(i, i + 200))
+    }
+
+    const keys = await apiClient.listKeysToServeByTag(projectId!, 'web', 'PR-bulk')
+    assert.equal(keys.length, TOTAL)
+    const names = new Set(keys.map(k => k.keyName))
+    assert.ok(names.has('bulk.0000'))
+    assert.ok(names.has('bulk.0599'))
+  })
+})
+
+describe('sourceFilterForL10nStorage (e2e)', () => {
+  let projectId: string | undefined
+
+  before(async () => {
+    if (!await isL10nApiAvailable()) {
+      throw new Error(
+        `tpc-agent l10n API not available at ${API_BASE}. `,
+      )
+    }
+    process.env.TPC_AGENT_TOKEN = DEV_TOKEN
+  })
+
+  beforeEach(async () => {
+    await deleteProject(projectId)
+    const created = await createProject('sf-impl-e2e', ['en', 'ko'], 'en')
+    projectId = created.projectId
+  })
+
+  after(async () => {
+    await deleteProject(projectId)
+  })
+
+  it('produces snapshots with translations and contexts from metadata', async () => {
+    const seeded = await seedKeys(projectId!, [{
+      keyName: 'ctx.key',
+      tags: [{ tag: 'web', source: 'PR-9' }],
+      metadata: [{ tag: 'web', metaKey: 'context', metaValue: JSON.stringify(['ctx1', 'ctx2']) }],
+      suggestions: [
+        { locale: 'en', translation: { other: 'Hello' }, suggestedBy: 'syncer' },
+        { locale: 'ko', translation: { other: '안녕' }, suggestedBy: 'syncer' },
+      ],
+    }])
+    await acceptAllSuggestions(seeded)
+
+    const config = buildL10nConfig(projectId!)
+    const snapshots = await sourceFilterForL10nStorage(config, buildDomainConfig(), 'web', 'PR-9')
+    assert.equal(snapshots.length, 1)
+    const snap = snapshots[0]
+    assert.equal(snap.keyName, 'ctx.key')
+    assert.deepEqual(snap.contexts.sort(), ['ctx1', 'ctx2'])
+    assert.deepEqual(snap.translations.en, { other: 'Hello' })
+    assert.deepEqual(snap.translations.ko, { other: '안녕' })
+  })
+
+  it('applies localeSyncMap inversion to snapshot translation locales', async () => {
+    const seeded = await seedKeys(projectId!, [{
+      keyName: 'mapped.key',
+      tags: [{ tag: 'web', source: 'PR-1' }],
+      suggestions: [
+        { locale: 'en', translation: { other: 'Mapped' }, suggestedBy: 'syncer' },
+        { locale: 'ko', translation: { other: '매핑됨' }, suggestedBy: 'syncer' },
+      ],
+    }])
+    await acceptAllSuggestions(seeded)
+
+    // 로컬 'ko-KR' ↔ 서버 'ko' 매핑
+    const config = buildL10nConfig(projectId!, { localeSyncMap: { 'ko-KR': 'ko' } })
+    const snapshots = await sourceFilterForL10nStorage(config, buildDomainConfig(), 'web', 'PR-1')
+    assert.equal(snapshots.length, 1)
+    const snap = snapshots[0]
+    assert.deepEqual(snap.translations['ko-KR'], { other: '매핑됨' })
+    assert.equal(snap.translations.ko, undefined)
+    assert.deepEqual(snap.translations.en, { other: 'Mapped' })
+  })
+
+  it('omits keys outside the requested (tag, source) pair', async () => {
+    await seedKeys(projectId!, [
+      { keyName: 'in.scope', tags: [{ tag: 'web', source: 'PR-X' }] },
+      { keyName: 'other.tag', tags: [{ tag: 'mobile', source: 'PR-X' }] },
+      { keyName: 'other.source', tags: [{ tag: 'web', source: 'main' }] },
+    ])
+
+    const config = buildL10nConfig(projectId!)
+    const snapshots = await sourceFilterForL10nStorage(config, buildDomainConfig(), 'web', 'PR-X')
+    const names = snapshots.map(s => s.keyName).sort()
+    assert.deepEqual(names, ['in.scope'])
+  })
+})

--- a/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/source-filter.e2e.test.ts
@@ -11,20 +11,10 @@ import {
   deleteProject,
   DEV_TOKEN,
   isL10nApiAvailable,
-  isSourceFilterEndpointAvailable,
   seedKeys,
 } from './helpers.js'
 
-const apiAvailable = await isL10nApiAvailable()
-const endpointAvailable = apiAvailable ? await isSourceFilterEndpointAvailable() : false
-
-const skipReason: string | false = !apiAvailable
-  ? `tpc-agent l10n API not available at ${API_BASE}`
-  : !endpointAvailable
-      ? 'tag/source keys-to-serve endpoint not deployed in tpc-agent (run a build with the new endpoint to enable)'
-      : false
-
-describe('listKeysToServeByTag (e2e)', { skip: skipReason }, () => {
+describe('listKeysToServeByTag (e2e)', () => {
   let apiClient: L10nStorageApiClient
   let projectId: string | undefined
 
@@ -123,7 +113,7 @@ describe('listKeysToServeByTag (e2e)', { skip: skipReason }, () => {
   })
 })
 
-describe('sourceFilterForL10nStorage (e2e)', { skip: skipReason }, () => {
+describe('sourceFilterForL10nStorage (e2e)', () => {
   let projectId: string | undefined
 
   before(async () => {

--- a/packages/syncer-l10n-storage/src/index.ts
+++ b/packages/syncer-l10n-storage/src/index.ts
@@ -1,11 +1,13 @@
 import type { L10nPlugin } from 'l10n-tools-core'
 import { syncTransToL10nStorage } from './l10n-storage.js'
+import { sourceFilterForL10nStorage } from './source-filter.js'
 
 const plugin: L10nPlugin = {
   name: 'l10n-tools-syncer-l10n-storage',
   syncers: [{
     syncTarget: 'l10n-storage',
     syncer: syncTransToL10nStorage,
+    sourceFilter: sourceFilterForL10nStorage,
   }],
 }
 

--- a/packages/syncer-l10n-storage/src/source-filter.test.ts
+++ b/packages/syncer-l10n-storage/src/source-filter.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { L10nKeyToServe } from './api-types.js'
+import { toSnapshot } from './source-filter.js'
+
+function createL10nKey(keyName: string, opts?: {
+  id?: string,
+  isPlural?: boolean,
+  tags?: { tag: string, source: string }[],
+  metadata?: { tag: string | null, metaKey: string, metaValue: string }[],
+  translations?: { locale: string, translation: Record<string, string> }[],
+}): L10nKeyToServe {
+  return {
+    id: opts?.id ?? Math.random().toString(),
+    keyName,
+    isPlural: opts?.isPlural ?? false,
+    tags: opts?.tags ?? [],
+    metadata: opts?.metadata ?? [],
+    translations: opts?.translations ?? [],
+  }
+}
+
+describe('toSnapshot', () => {
+  it('returns [null] context when metadata has no contexts', () => {
+    const key = createL10nKey('greet', {
+      translations: [{ locale: 'ko', translation: { other: '안녕' } }],
+    })
+    const snap = toSnapshot(key, 'web', undefined)
+    assert.deepEqual(snap.contexts, [null])
+    assert.equal(snap.keyName, 'greet')
+    assert.deepEqual(snap.translations.ko, { other: '안녕' })
+  })
+
+  it('uses contexts from metadata when present', () => {
+    const key = createL10nKey('greet', {
+      metadata: [{ tag: 'web', metaKey: 'context', metaValue: JSON.stringify(['ctx1', 'ctx2']) }],
+      translations: [{ locale: 'ko', translation: { other: '안녕' } }],
+    })
+    const snap = toSnapshot(key, 'web', undefined)
+    assert.deepEqual(snap.contexts, ['ctx1', 'ctx2'])
+  })
+
+  it('ignores contexts from other tags', () => {
+    const key = createL10nKey('greet', {
+      metadata: [{ tag: 'mobile', metaKey: 'context', metaValue: JSON.stringify(['ctx-mobile']) }],
+    })
+    const snap = toSnapshot(key, 'web', undefined)
+    assert.deepEqual(snap.contexts, [null])
+  })
+
+  it('applies invertedSyncMap to translation locales', () => {
+    const key = createL10nKey('greet', {
+      translations: [
+        { locale: 'ko-KR', translation: { other: '안녕' } },
+        { locale: 'en-US', translation: { other: 'hi' } },
+      ],
+    })
+    const invertedSyncMap = { 'ko-KR': 'ko', 'en-US': 'en' }
+    const snap = toSnapshot(key, 'web', invertedSyncMap)
+    assert.deepEqual(snap.translations.ko, { other: '안녕' })
+    assert.deepEqual(snap.translations.en, { other: 'hi' })
+    assert.equal(snap.translations['ko-KR'], undefined)
+  })
+
+  it('passes through plural translations preserving non-empty forms', () => {
+    const key = createL10nKey('items', {
+      isPlural: true,
+      translations: [{
+        locale: 'en',
+        translation: { one: 'item', other: 'items', few: '' },
+      }],
+    })
+    const snap = toSnapshot(key, 'web', undefined)
+    assert.deepEqual(snap.translations.en, { one: 'item', other: 'items' })
+  })
+
+  it('returns empty messages when non-plural translation has no other', () => {
+    const key = createL10nKey('greet', {
+      translations: [{ locale: 'ko', translation: {} }],
+    })
+    const snap = toSnapshot(key, 'web', undefined)
+    assert.deepEqual(snap.translations.ko, {})
+  })
+})

--- a/packages/syncer-l10n-storage/src/source-filter.ts
+++ b/packages/syncer-l10n-storage/src/source-filter.ts
@@ -1,0 +1,76 @@
+import { invert } from 'es-toolkit/compat'
+import type { DomainConfig, L10nConfig, SyncerKeySnapshot, TransMessages, TransPluralKey } from 'l10n-tools-core'
+import { L10nStorageApiClient } from './api-client.js'
+import type { L10nKeyToServe } from './api-types.js'
+import { getContextsFromMetadata } from './metadata.js'
+
+function assertBijectiveLocaleSyncMap(localeSyncMap: { [locale: string]: string }): void {
+  const seen: { [serverLocale: string]: string } = {}
+  for (const [localLocale, serverLocale] of Object.entries(localeSyncMap)) {
+    const existing = seen[serverLocale]
+    if (existing && existing !== localLocale) {
+      throw new Error(
+        `Invalid locale-sync-map: duplicated target locale "${serverLocale}" for "${existing}" and "${localLocale}"`,
+      )
+    }
+    seen[serverLocale] = localLocale
+  }
+}
+
+/** @internal exported for testing */
+export function toSnapshot(
+  key: L10nKeyToServe,
+  tag: string,
+  invertedSyncMap: { [locale: string]: string } | undefined,
+): SyncerKeySnapshot {
+  const contexts: (string | null)[] = getContextsFromMetadata(key.metadata, tag)
+  if (contexts.length === 0) contexts.push(null)
+
+  const translations: { [locale: string]: TransMessages } = {}
+  for (const tr of key.translations) {
+    const locale = invertedSyncMap?.[tr.locale] ?? tr.locale
+    let messages: TransMessages
+    if (key.isPlural) {
+      const m: TransMessages = {}
+      for (const [form, value] of Object.entries(tr.translation)) {
+        if (value) m[form as TransPluralKey] = value
+      }
+      messages = m
+    } else {
+      const v = tr.translation.other
+      messages = v ? { other: v } : {}
+    }
+    translations[locale] = messages
+  }
+
+  return {
+    keyName: key.keyName,
+    isPlural: key.isPlural,
+    contexts,
+    translations,
+  }
+}
+
+export async function sourceFilterForL10nStorage(
+  config: L10nConfig,
+  _domainConfig: DomainConfig,
+  tag: string,
+  source: string | undefined,
+): Promise<SyncerKeySnapshot[]> {
+  const storageConfig = config.getL10nStorageConfig()
+  const projectId = storageConfig.getProjectId()
+  const url = storageConfig.getUrl()
+
+  const token = process.env.TPC_AGENT_TOKEN
+  if (!token) {
+    throw new Error('TPC_AGENT_TOKEN environment variable is required')
+  }
+
+  const localeSyncMap = storageConfig.getLocaleSyncMap()
+  if (localeSyncMap) assertBijectiveLocaleSyncMap(localeSyncMap)
+  const invertedSyncMap = localeSyncMap ? invert(localeSyncMap) : undefined
+
+  const apiClient = new L10nStorageApiClient(url, token)
+  const keys = await apiClient.listKeysToServeByTag(projectId, tag, source)
+  return keys.map(key => toSnapshot(key, tag, invertedSyncMap))
+}


### PR DESCRIPTION
## Summary

PR별 source 마커를 활용해 두 CLI 명령에 `--source` 필터를 도입합니다.

- `check --source PR-nnn`: 해당 (도메인 tag, source) 페어에 속한 키만 untranslated 검사. 기존 file/context 필터와 AND.
- `_compile --source PR-nnn`: 해당 키 + 번역을 sync target에서 가져와 임시 trans dir에 풀어 컴파일. 로컬 캐시를 건드리지 않아 CI 게이트에 그대로 사용 가능.
- core 측에 `SyncerSourceFilterFunc` 옵셔널 plugin 능력을 도입해 CLI ↔ syncer 결합을 끊음. 현재는 l10n-storage syncer만 구현 — 다른 target은 명시적 에러.

서버 측 작업: tpc-agent에 `GET /api/l10n/projects/{id}/tags/{tag}/keys-to-serve?source=...` 신규 endpoint 추가가 머지/배포되어야 동작합니다.

## Test plan

- [x] 단위 테스트: `materializeSnapshotsToTempDir` (core), `toSnapshot` (syncer-l10n-storage)
- [x] E2E 테스트: `listKeysToServeByTag` (필터 시맨틱·페이지네이션·전체 tags 보존), `sourceFilterForL10nStorage` (locale-sync-map·context 메타·스코프 외 키 제외)
- [x] CLI 스모크 (수동, `/tmp/cli-smoke.sh`): tpc-agent dev 서버에서 다음을 검증
  - `check --source main` 통과 / `check --source PR-X` 실패 / `check` 전체 실패
  - `_compile --source PR-X`가 corrupted 로컬 캐시를 무시하고 서버 권위 데이터로 컴파일
  - `_compile` (필터 없음)이 로컬 캐시 그대로 사용
- [x] `npm run build` / `npm run lint` / `npm test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)