### PR TITLE
feat(cli): merge _compile --source output into existing files

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -422,19 +422,20 @@ async function run() {
       })
     })
 
-  type CompileOptions = {
+  type CompileCmdOptions = {
     source?: string,
   }
   program.command('_compile')
     .description('Write domain asset from translations (internal use only)')
     .option('--source <source>', 'compile only keys belonging to this source (l10n-storage only)')
-    .action(async (opts: CompileOptions, cmd: Command) => {
+    .action(async (opts: CompileCmdOptions, cmd: Command) => {
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
         if (opts.source) {
           const snapshots = await fetchSourceSnapshots(cmd.name(), config, domainConfig, opts.source)
+          const mergeKeys = new Set(snapshots.map(s => s.keyName))
           const tempDir = await materializeSnapshotsToTempDir(domainName, snapshots, domainConfig.getLocales())
           try {
-            await compileAll(domainName, domainConfig, tempDir)
+            await compileAll(domainName, domainConfig, tempDir, { mergeKeys })
           } finally {
             await fsp.rm(tempDir, { recursive: true, force: true })
           }

--- a/packages/compiler-gettext/src/compiler.test.ts
+++ b/packages/compiler-gettext/src/compiler.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import type { TransEntry } from 'l10n-tools-core'
-import { createPo, createPoEntry } from './compiler.js'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import * as gettextParser from 'gettext-parser'
+import { CompilerConfig, type TransEntry, writeTransEntries } from 'l10n-tools-core'
+import { compileToMo, compileToPoJson, createPo, createPoEntry, mergePoTranslations } from './compiler.js'
 
 function makeTransEntry(overrides: Partial<TransEntry> = {}): TransEntry {
   return {
@@ -90,5 +94,274 @@ describe('createPo', () => {
       makeTransEntry({ context: null, key: 'b', messages: { other: 'B' } }),
     ])
     assert.equal(Object.keys(po.translations['']).length, 2)
+  })
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+}
+
+async function writeTransFiles(dir: string, perLocale: { [locale: string]: TransEntry[] }): Promise<void> {
+  for (const [locale, entries] of Object.entries(perLocale)) {
+    await writeTransEntries(path.join(dir, `trans-${locale}.json`), entries)
+  }
+}
+
+function makePoJsonConfig(targetDir: string): CompilerConfig {
+  return new CompilerConfig({ 'type': 'po-json', 'target-dir': targetDir } as never)
+}
+
+function makeMoConfig(targetDir: string): CompilerConfig {
+  return new CompilerConfig({ 'type': 'mo', 'target-dir': targetDir } as never)
+}
+
+describe('mergePoTranslations', () => {
+  it('replaces matching msgid entries from base with fresh values', () => {
+    const base = createPo('d', 'en', [
+      makeTransEntry({ key: 'keep', messages: { other: 'KEEP' } }),
+      makeTransEntry({ key: 'drop', messages: { other: 'OLD' } }),
+    ])
+    const fresh = createPo('d', 'en', [
+      makeTransEntry({ key: 'drop', messages: { other: 'NEW' } }),
+    ])
+    const merged = mergePoTranslations(base, fresh, new Set(['drop']))
+    assert.equal(merged.translations[''].keep.msgstr[0], 'KEEP')
+    assert.equal(merged.translations[''].drop.msgstr[0], 'NEW')
+  })
+
+  it('removes mergeKey msgid entries when fresh has no replacement', () => {
+    const base = createPo('d', 'en', [
+      makeTransEntry({ key: 'keep', messages: { other: 'KEEP' } }),
+      makeTransEntry({ key: 'gone', messages: { other: 'X' } }),
+    ])
+    const fresh = createPo('d', 'en', [])
+    const merged = mergePoTranslations(base, fresh, new Set(['gone']))
+    assert.equal(merged.translations[''].gone, undefined)
+    assert.equal(merged.translations[''].keep.msgstr[0], 'KEEP')
+  })
+
+  it('removes mergeKey entries across all msgctxt buckets', () => {
+    const base = createPo('d', 'en', [
+      makeTransEntry({ context: 'menu', key: 'File', messages: { other: 'M-File' } }),
+      makeTransEntry({ context: 'menu', key: 'keep', messages: { other: 'M-keep' } }),
+      makeTransEntry({ context: 'toolbar', key: 'File', messages: { other: 'T-File' } }),
+    ])
+    const fresh = createPo('d', 'en', [
+      makeTransEntry({ context: 'menu', key: 'File', messages: { other: 'M-File-NEW' } }),
+    ])
+    const merged = mergePoTranslations(base, fresh, new Set(['File']))
+    assert.equal(merged.translations.menu.File.msgstr[0], 'M-File-NEW')
+    assert.equal(merged.translations.menu.keep.msgstr[0], 'M-keep')
+    // Other-context entry with same msgid is removed too (no fresh replacement).
+    assert.equal(merged.translations.toolbar?.File, undefined)
+  })
+
+  it('preserves base headers and ignores fresh headers entry', () => {
+    const base = createPo('myDomain', 'en', [])
+    base.headers['Project-Id-Version'] = 'baseProject'
+    const fresh = createPo('otherDomain', 'en', [])
+    const merged = mergePoTranslations(base, fresh, new Set(['drop']))
+    assert.equal(merged.headers['Project-Id-Version'], 'baseProject')
+    // The empty-msgid header bucket under '' is still present (createPo populates it lazily).
+    assert.ok(merged.translations[''])
+  })
+
+  it('does not mutate the base object', () => {
+    const base = createPo('d', 'en', [
+      makeTransEntry({ key: 'drop', messages: { other: 'OLD' } }),
+    ])
+    const fresh = createPo('d', 'en', [
+      makeTransEntry({ key: 'drop', messages: { other: 'NEW' } }),
+    ])
+    mergePoTranslations(base, fresh, new Set(['drop']))
+    assert.equal(base.translations[''].drop.msgstr[0], 'OLD')
+  })
+})
+
+describe('compileToPoJson with mergeKeys', () => {
+  it('updates only PR keys in the per-locale PO JSON output', async () => {
+    const dir = await makeTempDir('compile-pojson-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+
+      const baseKo = createPo('d', 'ko', [
+        makeTransEntry({ key: 'keep', messages: { other: '유지' } }),
+        makeTransEntry({ key: 'drop', messages: { other: '낡은' } }),
+      ])
+      await fsp.writeFile(path.join(targetDir, 'ko.json'), JSON.stringify(baseKo, null, 2))
+
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: { other: '새' } })],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(targetDir), transDir, {
+        mergeKeys: new Set(['drop']),
+      })
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.equal(written.translations[''].keep.msgstr[0], '유지')
+      assert.equal(written.translations[''].drop.msgstr[0], '새')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch any locale file when mergeKeys is empty', async () => {
+    const dir = await makeTempDir('compile-pojson-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      const original = JSON.stringify(createPo('d', 'ko', [
+        makeTransEntry({ key: 'keep', messages: { other: '유지' } }),
+      ]), null, 2)
+      await fsp.writeFile(path.join(targetDir, 'ko.json'), original)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'unrelated', messages: { other: 'X' } })],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(targetDir), transDir, {
+        mergeKeys: new Set(),
+      })
+
+      const after = await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8')
+      assert.equal(after, original)
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes only PR keys when the locale PO JSON file does not exist yet', async () => {
+    const dir = await makeTempDir('compile-pojson-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'a', messages: { other: 'A' } })],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(targetDir), transDir, {
+        mergeKeys: new Set(['a']),
+      })
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.equal(written.translations[''].a.msgstr[0], 'A')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('overwrites the entire file when mergeKeys is not provided', async () => {
+    const dir = await makeTempDir('compile-pojson-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(path.join(targetDir, 'ko.json'),
+        JSON.stringify(createPo('d', 'ko', [makeTransEntry({ key: 'stale', messages: { other: 'X' } })])))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'fresh', messages: { other: 'F' } })],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(targetDir), transDir)
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.equal(written.translations[''].stale, undefined)
+      assert.equal(written.translations[''].fresh.msgstr[0], 'F')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('compileToMo with mergeKeys', () => {
+  it('updates only PR keys in the per-locale .mo binary', async () => {
+    const dir = await makeTempDir('compile-mo-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+
+      // Seed an existing .mo file with two keys.
+      const moDir = path.join(targetDir, 'ko', 'LC_MESSAGES')
+      await fsp.mkdir(moDir, { recursive: true })
+      const baseKo = createPo('d', 'ko', [
+        makeTransEntry({ key: 'keep', messages: { other: '유지' } }),
+        makeTransEntry({ key: 'drop', messages: { other: '낡은' } }),
+      ])
+      await fsp.writeFile(path.join(moDir, 'd.mo'), gettextParser.mo.compile(baseKo))
+
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: { other: '새' } })],
+      })
+
+      await compileToMo('d', makeMoConfig(targetDir), transDir, {
+        mergeKeys: new Set(['drop']),
+      })
+
+      const buf = await fsp.readFile(path.join(moDir, 'd.mo'))
+      const parsed = gettextParser.mo.parse(buf)
+      assert.equal(parsed.translations[''].keep.msgstr[0], '유지')
+      assert.equal(parsed.translations[''].drop.msgstr[0], '새')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch any .mo file when mergeKeys is empty', async () => {
+    const dir = await makeTempDir('compile-mo-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      const moDir = path.join(targetDir, 'ko', 'LC_MESSAGES')
+      await fsp.mkdir(moDir, { recursive: true })
+      const baseKo = createPo('d', 'ko', [
+        makeTransEntry({ key: 'keep', messages: { other: '유지' } }),
+      ])
+      const originalBytes = gettextParser.mo.compile(baseKo)
+      await fsp.writeFile(path.join(moDir, 'd.mo'), originalBytes)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'unrelated', messages: { other: 'X' } })],
+      })
+
+      await compileToMo('d', makeMoConfig(targetDir), transDir, {
+        mergeKeys: new Set(),
+      })
+
+      const after = await fsp.readFile(path.join(moDir, 'd.mo'))
+      assert.deepEqual(Buffer.from(after), Buffer.from(originalBytes))
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes only PR keys when the locale .mo file does not exist yet', async () => {
+    const dir = await makeTempDir('compile-mo-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'a', messages: { other: 'A' } })],
+      })
+
+      await compileToMo('d', makeMoConfig(targetDir), transDir, {
+        mergeKeys: new Set(['a']),
+      })
+
+      const moPath = path.join(targetDir, 'ko', 'LC_MESSAGES', 'd.mo')
+      const buf = await fsp.readFile(moPath)
+      const parsed = gettextParser.mo.parse(buf)
+      assert.equal(parsed.translations[''].a.msgstr[0], 'A')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/compiler-gettext/src/compiler.test.ts
+++ b/packages/compiler-gettext/src/compiler.test.ts
@@ -129,18 +129,7 @@ describe('mergePoTranslations', () => {
     assert.equal(merged.translations[''].drop.msgstr[0], 'NEW')
   })
 
-  it('removes mergeKey msgid entries when fresh has no replacement', () => {
-    const base = createPo('d', 'en', [
-      makeTransEntry({ key: 'keep', messages: { other: 'KEEP' } }),
-      makeTransEntry({ key: 'gone', messages: { other: 'X' } }),
-    ])
-    const fresh = createPo('d', 'en', [])
-    const merged = mergePoTranslations(base, fresh, new Set(['gone']))
-    assert.equal(merged.translations[''].gone, undefined)
-    assert.equal(merged.translations[''].keep.msgstr[0], 'KEEP')
-  })
-
-  it('removes mergeKey entries across all msgctxt buckets', () => {
+  it('replaces only the (msgctxt, msgid) pairs present in fresh, preserving same-msgid in other contexts', () => {
     const base = createPo('d', 'en', [
       makeTransEntry({ context: 'menu', key: 'File', messages: { other: 'M-File' } }),
       makeTransEntry({ context: 'menu', key: 'keep', messages: { other: 'M-keep' } }),
@@ -152,8 +141,21 @@ describe('mergePoTranslations', () => {
     const merged = mergePoTranslations(base, fresh, new Set(['File']))
     assert.equal(merged.translations.menu.File.msgstr[0], 'M-File-NEW')
     assert.equal(merged.translations.menu.keep.msgstr[0], 'M-keep')
-    // Other-context entry with same msgid is removed too (no fresh replacement).
-    assert.equal(merged.translations.toolbar?.File, undefined)
+    // Same msgid in an unrelated msgctxt is preserved — fresh did not replace (toolbar, File).
+    assert.equal(merged.translations.toolbar.File.msgstr[0], 'T-File')
+  })
+
+  it('preserves base entries whose pair is not in fresh, even when msgid happens to be in mergeKeys', () => {
+    // Pins the contract: the merge unit is (msgctxt, msgid). mergeKeys never causes
+    // deletions on its own — only fresh's contents drive replacements.
+    const base = createPo('d', 'en', [
+      makeTransEntry({ key: 'keep', messages: { other: 'KEEP' } }),
+      makeTransEntry({ key: 'gone', messages: { other: 'X' } }),
+    ])
+    const fresh = createPo('d', 'en', [])
+    const merged = mergePoTranslations(base, fresh, new Set(['gone']))
+    assert.equal(merged.translations[''].gone.msgstr[0], 'X')
+    assert.equal(merged.translations[''].keep.msgstr[0], 'KEEP')
   })
 
   it('preserves base headers and ignores fresh headers entry', () => {

--- a/packages/compiler-gettext/src/compiler.ts
+++ b/packages/compiler-gettext/src/compiler.ts
@@ -124,15 +124,20 @@ export function createPoEntry(locale: string, transEntry: TransEntry): GetTextTr
 }
 
 /**
- * Merge `fresh` PO (built from PR-N keys) into `base` PO so that any (msgctxt, msgid)
- * with msgid in `mergeKeys` is taken from `fresh` and all other entries are preserved.
+ * Merge `fresh` PO (built from PR-N keys) into `base` PO. The merge unit is the
+ * `(msgctxt, msgid)` pair: any pair present in `fresh` replaces the corresponding pair
+ * in `base`, and every other base entry — including same-msgid entries that live under
+ * a different msgctxt — is preserved unchanged.
+ *
+ * `mergeKeys` is currently unused inside the merge but is kept on the signature for
+ * symmetry with other compilers and to enable future deletion semantics if needed.
  *
  * @internal exported for testing
  */
 export function mergePoTranslations(
   base: GetTextTranslations,
   fresh: GetTextTranslations,
-  mergeKeys: Set<string>,
+  _mergeKeys: Set<string>,
 ): GetTextTranslations {
   // Start with a deep-ish clone of base translations (one level enough since
   // each msgid maps to a fresh GetTextTranslation object reference we treat as immutable).
@@ -145,19 +150,7 @@ export function mergePoTranslations(
     merged.translations[msgctxt] = { ...entries }
   }
 
-  // Drop all (msgctxt, msgid) where msgid is a mergeKey.
-  for (const msgctxt of Object.keys(merged.translations)) {
-    for (const msgid of Object.keys(merged.translations[msgctxt])) {
-      if (mergeKeys.has(msgid)) {
-        delete merged.translations[msgctxt][msgid]
-      }
-    }
-    if (Object.keys(merged.translations[msgctxt]).length === 0 && msgctxt !== '') {
-      delete merged.translations[msgctxt]
-    }
-  }
-
-  // Add fresh entries.
+  // Replace base's (msgctxt, msgid) with fresh's value for every pair fresh actually contains.
   for (const [msgctxt, entries] of Object.entries(fresh.translations)) {
     if (merged.translations[msgctxt] == null) {
       merged.translations[msgctxt] = {}

--- a/packages/compiler-gettext/src/compiler.ts
+++ b/packages/compiler-gettext/src/compiler.ts
@@ -4,31 +4,60 @@ import * as gettextParser from 'gettext-parser'
 import type { GetTextTranslation, GetTextTranslations } from 'gettext-parser'
 import fsp from 'node:fs/promises'
 import {
+  type CompileOptions,
   type CompilerConfig,
   extractLocaleFromTransPath,
   getPluralKeys,
+  isErrnoException,
   listTransPaths,
   readTransEntries,
   type TransEntry,
 } from 'l10n-tools-core'
 
-export async function compileToPoJson(domainName: string, config: CompilerConfig, transDir: string) {
+export async function compileToPoJson(
+  domainName: string,
+  config: CompilerConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
   const targetDir = config.getTargetDir()
+  const mergeKeys = options?.mergeKeys
+
+  if (mergeKeys != null && mergeKeys.size === 0) {
+    return
+  }
+
   log.info('compile', `generating json files to '${targetDir}/${domainName}/{locale}.json'`)
   await fsp.mkdir(targetDir, { recursive: true })
   const transPaths = await listTransPaths(transDir)
   for (const transPath of transPaths) {
     const locale = extractLocaleFromTransPath(transPath)
     const jsonPath = path.join(targetDir, locale + '.json')
-    const po = createPo(domainName, locale, await readTransEntries(transPath))
+    let po = createPo(domainName, locale, await readTransEntries(transPath))
+
+    if (mergeKeys != null) {
+      const base = await readPoJsonIfExists(jsonPath, domainName, locale)
+      po = mergePoTranslations(base, po, mergeKeys)
+    }
 
     await fsp.mkdir(targetDir, { recursive: true })
     await fsp.writeFile(jsonPath, JSON.stringify(po, null, 2))
   }
 }
 
-export async function compileToMo(domainName: string, config: CompilerConfig, transDir: string) {
+export async function compileToMo(
+  domainName: string,
+  config: CompilerConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
   const targetDir = config.getTargetDir()
+  const mergeKeys = options?.mergeKeys
+
+  if (mergeKeys != null && mergeKeys.size === 0) {
+    return
+  }
+
   log.info('compile', `generating mo files to '${targetDir}/{locale}/LC_MESSAGES/${domainName}.mo'`)
   await fsp.mkdir(targetDir, { recursive: true })
   const transPaths = await listTransPaths(transDir)
@@ -37,7 +66,11 @@ export async function compileToMo(domainName: string, config: CompilerConfig, tr
     const moDir = path.join(targetDir, locale, 'LC_MESSAGES')
     const moPath = path.join(moDir, domainName + '.mo')
 
-    const po = createPo(domainName, locale, await readTransEntries(transPath))
+    let po = createPo(domainName, locale, await readTransEntries(transPath))
+    if (mergeKeys != null) {
+      const base = await readMoIfExists(moPath, domainName, locale)
+      po = mergePoTranslations(base, po, mergeKeys)
+    }
     const output = gettextParser.mo.compile(po)
 
     await fsp.mkdir(moDir, { recursive: true })
@@ -88,4 +121,108 @@ export function createPoEntry(locale: string, transEntry: TransEntry): GetTextTr
       msgstr: msgstr,
     }
   }
+}
+
+/**
+ * Merge `fresh` PO (built from PR-N keys) into `base` PO so that any (msgctxt, msgid)
+ * with msgid in `mergeKeys` is taken from `fresh` and all other entries are preserved.
+ *
+ * @internal exported for testing
+ */
+export function mergePoTranslations(
+  base: GetTextTranslations,
+  fresh: GetTextTranslations,
+  mergeKeys: Set<string>,
+): GetTextTranslations {
+  // Start with a deep-ish clone of base translations (one level enough since
+  // each msgid maps to a fresh GetTextTranslation object reference we treat as immutable).
+  const merged: GetTextTranslations = {
+    ...base,
+    headers: { ...base.headers },
+    translations: {},
+  }
+  for (const [msgctxt, entries] of Object.entries(base.translations)) {
+    merged.translations[msgctxt] = { ...entries }
+  }
+
+  // Drop all (msgctxt, msgid) where msgid is a mergeKey.
+  for (const msgctxt of Object.keys(merged.translations)) {
+    for (const msgid of Object.keys(merged.translations[msgctxt])) {
+      if (mergeKeys.has(msgid)) {
+        delete merged.translations[msgctxt][msgid]
+      }
+    }
+    if (Object.keys(merged.translations[msgctxt]).length === 0 && msgctxt !== '') {
+      delete merged.translations[msgctxt]
+    }
+  }
+
+  // Add fresh entries.
+  for (const [msgctxt, entries] of Object.entries(fresh.translations)) {
+    if (merged.translations[msgctxt] == null) {
+      merged.translations[msgctxt] = {}
+    }
+    for (const [msgid, entry] of Object.entries(entries)) {
+      // gettext-parser uses an empty-msgid entry under the empty msgctxt for headers.
+      // Always keep base headers; never let fresh's headers entry leak through.
+      if (msgctxt === '' && msgid === '') {
+        continue
+      }
+      merged.translations[msgctxt][msgid] = entry
+    }
+  }
+
+  // Ensure the empty-msgid header entry under '' exists (matches createPo output shape).
+  if (merged.translations[''] == null) {
+    merged.translations[''] = {}
+  }
+
+  return merged
+}
+
+async function readPoJsonIfExists(
+  jsonPath: string,
+  domainName: string,
+  locale: string,
+): Promise<GetTextTranslations> {
+  try {
+    const text = await fsp.readFile(jsonPath, { encoding: 'utf-8' })
+    const parsed = JSON.parse(text) as GetTextTranslations
+    if (parsed.translations == null) {
+      return emptyPo(domainName, locale)
+    }
+    if (parsed.headers == null) {
+      parsed.headers = emptyPo(domainName, locale).headers
+    }
+    return parsed
+  } catch (err) {
+    if (isErrnoException(err, 'ENOENT')) {
+      return emptyPo(domainName, locale)
+    }
+    throw err
+  }
+}
+
+async function readMoIfExists(
+  moPath: string,
+  domainName: string,
+  locale: string,
+): Promise<GetTextTranslations> {
+  try {
+    const buffer = await fsp.readFile(moPath)
+    const parsed = gettextParser.mo.parse(buffer) as GetTextTranslations
+    if (parsed?.translations == null) {
+      return emptyPo(domainName, locale)
+    }
+    return parsed
+  } catch (err) {
+    if (isErrnoException(err, 'ENOENT')) {
+      return emptyPo(domainName, locale)
+    }
+    throw err
+  }
+}
+
+function emptyPo(domainName: string, locale: string): GetTextTranslations {
+  return createPo(domainName, locale, [])
 }

--- a/packages/compiler-json/src/compiler.test.ts
+++ b/packages/compiler-json/src/compiler.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import type { TransEntry } from 'l10n-tools-core'
-import { buildJsonTrans } from './compiler.js'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { CompilerConfig, type TransEntry, writeTransEntries } from 'l10n-tools-core'
+import { buildJsonTrans, compileToJson, compileToJsonDir, jsonKeyMatchesMergeKeys, mergeJsonTrans } from './compiler.js'
 
 function makeTransEntry(overrides: Partial<TransEntry> = {}): TransEntry {
   return {
@@ -10,6 +13,31 @@ function makeTransEntry(overrides: Partial<TransEntry> = {}): TransEntry {
     messages: overrides.messages ?? { other: 'translated' },
     flag: overrides.flag ?? null,
   }
+}
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+}
+
+async function writeTransFiles(
+  dir: string,
+  perLocale: { [locale: string]: TransEntry[] },
+): Promise<void> {
+  for (const [locale, entries] of Object.entries(perLocale)) {
+    await writeTransEntries(path.join(dir, `trans-${locale}.json`), entries)
+  }
+}
+
+function makeJsonConfig(targetPath: string): CompilerConfig {
+  return new CompilerConfig({ 'type': 'json', 'target-path': targetPath } as never)
+}
+
+function makeJsonDirConfig(targetDir: string, useLocaleKey = false): CompilerConfig {
+  return new CompilerConfig({
+    'type': 'json-dir',
+    'target-dir': targetDir,
+    'use-locale-key': useLocaleKey,
+  } as never)
 }
 
 describe('buildJsonTrans', () => {
@@ -100,5 +128,344 @@ describe('buildJsonTrans', () => {
         item_other: 'many',
       })
     })
+  })
+})
+
+describe('jsonKeyMatchesMergeKeys', () => {
+  it('matches direct key membership', () => {
+    const set = new Set(['a', 'b'])
+    assert.equal(jsonKeyMatchesMergeKeys('a', set), true)
+    assert.equal(jsonKeyMatchesMergeKeys('c', set), false)
+  })
+
+  it('does not match plural-suffixed keys without i18next pluralType', () => {
+    const set = new Set(['item'])
+    assert.equal(jsonKeyMatchesMergeKeys('item_one', set), false)
+    assert.equal(jsonKeyMatchesMergeKeys('item_other', set), false)
+  })
+
+  it('matches `${key}_<form>` when pluralType is i18next', () => {
+    const set = new Set(['item'])
+    for (const form of ['zero', 'one', 'two', 'few', 'many', 'other']) {
+      assert.equal(
+        jsonKeyMatchesMergeKeys(`item_${form}`, set, 'i18next'),
+        true,
+        `expected match for item_${form}`,
+      )
+    }
+    assert.equal(jsonKeyMatchesMergeKeys('item_unknown', set, 'i18next'), false)
+    assert.equal(jsonKeyMatchesMergeKeys('other_item_one', set, 'i18next'), false)
+  })
+
+  it('still matches direct hits in i18next mode', () => {
+    const set = new Set(['weird_key'])
+    assert.equal(jsonKeyMatchesMergeKeys('weird_key', set, 'i18next'), true)
+  })
+})
+
+describe('mergeJsonTrans', () => {
+  it('replaces matching keys from base with fresh values', () => {
+    const base = { a: 'old A', b: 'B', c: 'C' }
+    const fresh = { a: 'new A' }
+    const result = mergeJsonTrans(base, fresh, new Set(['a']))
+    assert.deepEqual(result, { a: 'new A', b: 'B', c: 'C' })
+  })
+
+  it('removes mergeKeys from base when fresh has no value', () => {
+    const base = { a: 'A', b: 'B' }
+    const fresh = {}
+    const result = mergeJsonTrans(base, fresh, new Set(['a']))
+    assert.deepEqual(result, { b: 'B' })
+  })
+
+  it('adds fresh keys not already in base', () => {
+    const base = { b: 'B' }
+    const fresh = { a: 'A' }
+    const result = mergeJsonTrans(base, fresh, new Set(['a']))
+    assert.deepEqual(result, { a: 'A', b: 'B' })
+  })
+
+  it('does not mutate the base object', () => {
+    const base = { a: 'old', b: 'B' }
+    mergeJsonTrans(base, { a: 'new' }, new Set(['a']))
+    assert.deepEqual(base, { a: 'old', b: 'B' })
+  })
+
+  it('clears all i18next plural-suffixed forms of a mergeKey, even when fresh has fewer forms', () => {
+    const base = { item_zero: '0', item_one: '1', item_other: 'many', greet: 'hi' }
+    const fresh = { item_one: 'one', item_other: 'others' }
+    const result = mergeJsonTrans(base, fresh, new Set(['item']), 'i18next')
+    assert.deepEqual(result, { item_one: 'one', item_other: 'others', greet: 'hi' })
+  })
+
+  it('preserves i18next-suffixed keys that do not belong to mergeKeys', () => {
+    const base = { item_one: '1', other_one: 'X' }
+    const fresh = { item_one: 'one' }
+    const result = mergeJsonTrans(base, fresh, new Set(['item']), 'i18next')
+    assert.deepEqual(result, { item_one: 'one', other_one: 'X' })
+  })
+})
+
+describe('compileToJson with mergeKeys', () => {
+  it('updates only PR keys in the existing single-file output', async () => {
+    const dir = await makeTempDir('compile-json-merge-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+
+      // Existing output: ko has both keep + drop keys; en has keep only.
+      await fsp.writeFile(targetPath, JSON.stringify({
+        ko: { keep: '유지', drop: '낡은값' },
+        en: { keep: 'keep' },
+      }, null, 2))
+
+      // PR snapshot only contains "drop" (now refreshed).
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: { other: '새값' } })],
+        en: [makeTransEntry({ key: 'drop', messages: { other: 'fresh' } })],
+      })
+
+      const config = makeJsonConfig(targetPath)
+      await compileToJson('d', config, transDir, { mergeKeys: new Set(['drop']) })
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(written, {
+        ko: { keep: '유지', drop: '새값' },
+        en: { keep: 'keep', drop: 'fresh' },
+      })
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('removes PR keys from the output when fresh translation is empty', async () => {
+    const dir = await makeTempDir('compile-json-merge-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(targetPath, JSON.stringify({
+        ko: { keep: '유지', drop: '제거대상' },
+      }, null, 2))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: {} })],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir, {
+        mergeKeys: new Set(['drop']),
+      })
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(written, { ko: { keep: '유지' } })
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch the output when mergeKeys is empty', async () => {
+    const dir = await makeTempDir('compile-json-merge-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      const original = JSON.stringify({ ko: { keep: '유지' } }, null, 2)
+      await fsp.writeFile(targetPath, original)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'unrelated', messages: { other: 'X' } })],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir, {
+        mergeKeys: new Set(),
+      })
+
+      const after = await fsp.readFile(targetPath, 'utf-8')
+      assert.equal(after, original)
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes only PR keys when the output file does not exist yet', async () => {
+    const dir = await makeTempDir('compile-json-merge-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'a', messages: { other: 'A' } })],
+        en: [makeTransEntry({ key: 'a', messages: { other: 'A-en' } })],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir, {
+        mergeKeys: new Set(['a']),
+      })
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(written, {
+        ko: { a: 'A' },
+        en: { a: 'A-en' },
+      })
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('overwrites the entire file when mergeKeys is not provided', async () => {
+    const dir = await makeTempDir('compile-json-merge-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(targetPath, JSON.stringify({ ko: { stale: 'X' } }))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'fresh', messages: { other: 'F' } })],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir)
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(written, { ko: { fresh: 'F' } })
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('compileToJsonDir with mergeKeys', () => {
+  it('updates only PR keys per locale, preserving other keys', async () => {
+    const dir = await makeTempDir('compile-jsondir-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(path.join(targetDir, 'ko.json'),
+        JSON.stringify({ keep: '유지', drop: '낡은' }, null, 2))
+      await fsp.writeFile(path.join(targetDir, 'en.json'),
+        JSON.stringify({ keep: 'keep', drop: 'old' }, null, 2))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: { other: '새' } })],
+        en: [makeTransEntry({ key: 'drop', messages: { other: 'new' } })],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir), transDir, {
+        mergeKeys: new Set(['drop']),
+      })
+
+      assert.deepEqual(
+        JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8')),
+        { keep: '유지', drop: '새' },
+      )
+      assert.deepEqual(
+        JSON.parse(await fsp.readFile(path.join(targetDir, 'en.json'), 'utf-8')),
+        { keep: 'keep', drop: 'new' },
+      )
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads base from useLocaleKey wrapper and writes back wrapped', async () => {
+    const dir = await makeTempDir('compile-jsondir-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(path.join(targetDir, 'ko.json'),
+        JSON.stringify({ ko: { keep: '유지', drop: '낡은' } }, null, 2))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'drop', messages: { other: '새' } })],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir, true), transDir, {
+        mergeKeys: new Set(['drop']),
+      })
+
+      assert.deepEqual(
+        JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8')),
+        { ko: { keep: '유지', drop: '새' } },
+      )
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch any locale file when mergeKeys is empty', async () => {
+    const dir = await makeTempDir('compile-jsondir-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      const koOriginal = JSON.stringify({ keep: '유지' }, null, 2)
+      const enOriginal = JSON.stringify({ keep: 'keep' }, null, 2)
+      await fsp.writeFile(path.join(targetDir, 'ko.json'), koOriginal)
+      await fsp.writeFile(path.join(targetDir, 'en.json'), enOriginal)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'unrelated', messages: { other: 'X' } })],
+        en: [makeTransEntry({ key: 'unrelated', messages: { other: 'X' } })],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir), transDir, {
+        mergeKeys: new Set(),
+      })
+
+      assert.equal(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'), koOriginal)
+      assert.equal(await fsp.readFile(path.join(targetDir, 'en.json'), 'utf-8'), enOriginal)
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes only PR keys when the locale file does not exist yet', async () => {
+    const dir = await makeTempDir('compile-jsondir-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'a', messages: { other: 'A' } })],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir), transDir, {
+        mergeKeys: new Set(['a']),
+      })
+
+      assert.deepEqual(
+        JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8')),
+        { a: 'A' },
+      )
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('clears all i18next plural-suffixed forms of a mergeKey from the base', async () => {
+    const dir = await makeTempDir('compile-jsondir-merge-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(path.join(targetDir, 'en.json'),
+        JSON.stringify({ keep: 'keep', item_zero: '0', item_one: '1', item_other: 'many' }, null, 2))
+      await writeTransFiles(transDir, {
+        en: [makeTransEntry({ key: 'item', messages: { one: 'one', other: 'others' } })],
+      })
+
+      await compileToJsonDir('i18next')('d', new CompilerConfig({
+        'type': 'i18next',
+        'target-dir': targetDir,
+      } as never), transDir, { mergeKeys: new Set(['item']) })
+
+      assert.deepEqual(
+        JSON.parse(await fsp.readFile(path.join(targetDir, 'en.json'), 'utf-8')),
+        { keep: 'keep', item_one: 'one', item_other: 'others' },
+      )
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/compiler-json/src/compiler.test.ts
+++ b/packages/compiler-json/src/compiler.test.ts
@@ -204,6 +204,27 @@ describe('mergeJsonTrans', () => {
     const result = mergeJsonTrans(base, fresh, new Set(['item']), 'i18next')
     assert.deepEqual(result, { item_one: 'one', other_one: 'X' })
   })
+
+  it('does not let fresh keys outside mergeKeys overwrite base', () => {
+    // Defensive: fresh is normally produced from PR-scope trans only, but if an
+    // unrelated key ever leaks in, the merge must not propagate it.
+    const base = { keep: 'BASE' }
+    const fresh = { keep: 'LEAKED', drop: 'NEW' }
+    const result = mergeJsonTrans(base, fresh, new Set(['drop']))
+    assert.deepEqual(result, { keep: 'BASE', drop: 'NEW' })
+  })
+
+  it('does not let fresh i18next plural keys outside mergeKeys overwrite base', () => {
+    const base = { keep_one: 'BASE-one', keep_other: 'BASE-many' }
+    const fresh = { keep_one: 'LEAKED', drop_one: 'NEW-one', drop_other: 'NEW-many' }
+    const result = mergeJsonTrans(base, fresh, new Set(['drop']), 'i18next')
+    assert.deepEqual(result, {
+      keep_one: 'BASE-one',
+      keep_other: 'BASE-many',
+      drop_one: 'NEW-one',
+      drop_other: 'NEW-many',
+    })
+  })
 })
 
 describe('compileToJson with mergeKeys', () => {

--- a/packages/compiler-json/src/compiler.ts
+++ b/packages/compiler-json/src/compiler.ts
@@ -150,7 +150,11 @@ export function jsonKeyMatchesMergeKeys(
 
 /**
  * Merge `fresh` (output for PR-N keys only) into `base` (existing output) such that
- * keys in `mergeKeys` are taken from `fresh` and all other keys are preserved.
+ * only keys in `mergeKeys` are taken from `fresh` and all other keys are preserved.
+ *
+ * Both the deletion sweep on `base` and the assignment from `fresh` are gated by
+ * {@link jsonKeyMatchesMergeKeys}, so an unrelated key that happens to leak into
+ * `fresh` cannot overwrite `base` in merge mode.
  *
  * @internal exported for testing
  */
@@ -167,6 +171,9 @@ export function mergeJsonTrans(
     }
   }
   for (const [key, value] of Object.entries(fresh)) {
+    if (!jsonKeyMatchesMergeKeys(key, mergeKeys, pluralType)) {
+      continue
+    }
     result[key] = value
   }
   return result

--- a/packages/compiler-json/src/compiler.ts
+++ b/packages/compiler-json/src/compiler.ts
@@ -2,23 +2,47 @@ import log from 'npmlog'
 import path from 'path'
 import fsp from 'node:fs/promises'
 import {
+  type CompileOptions,
   type CompilerConfig,
   extractLocaleFromTransPath,
   getPluralKeys,
+  isErrnoException,
   listTransPaths,
   readTransEntries,
   type TransEntry,
 } from 'l10n-tools-core'
 
-export async function compileToJson(domainName: string, config: CompilerConfig, transDir: string) {
+export async function compileToJson(
+  domainName: string,
+  config: CompilerConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
   const targetPath = config.getTargetPath()
+  const mergeKeys = options?.mergeKeys
+
+  // No keys to update: leave the existing output untouched.
+  if (mergeKeys != null && mergeKeys.size === 0) {
+    return
+  }
+
   log.info('compile', `generating json file to '${targetPath}'`)
 
-  const translations: { [locale: string]: JsonTrans } = {}
+  let translations: { [locale: string]: JsonTrans } = {}
+  if (mergeKeys != null) {
+    translations = (await readJsonIfExists(targetPath)) as { [locale: string]: JsonTrans } | null ?? {}
+  }
+
   const transPaths = await listTransPaths(transDir)
   for (const transPath of transPaths) {
     const locale = extractLocaleFromTransPath(transPath)
-    translations[locale] = await exportTransToJson(locale, transPath)
+    const fresh = await exportTransToJson(locale, transPath)
+    if (mergeKeys != null) {
+      const base = translations[locale] ?? {}
+      translations[locale] = mergeJsonTrans(base, fresh, mergeKeys)
+    } else {
+      translations[locale] = fresh
+    }
   }
   await fsp.writeFile(targetPath, JSON.stringify(translations, null, 2))
 }
@@ -26,21 +50,37 @@ export async function compileToJson(domainName: string, config: CompilerConfig, 
 export type JsonPluralType = 'vue-i18n' | 'node-i18n' | 'i18next'
 
 export function compileToJsonDir(pluralType?: JsonPluralType) {
-  return async function (domainName: string, config: CompilerConfig, transDir: string) {
+  return async function (
+    domainName: string,
+    config: CompilerConfig,
+    transDir: string,
+    options?: CompileOptions,
+  ) {
     const targetDir = config.getTargetDir()
     const useLocaleKey = config.useLocaleKey()
+    const mergeKeys = options?.mergeKeys
+
+    if (mergeKeys != null && mergeKeys.size === 0) {
+      return
+    }
+
     log.info('compile', `generating json files '${targetDir}/{locale}.json' (locale key: ${useLocaleKey})`)
 
     await fsp.mkdir(targetDir, { recursive: true })
     const transPaths = await listTransPaths(transDir)
     for (const transPath of transPaths) {
       const locale = extractLocaleFromTransPath(transPath)
-      const json = await exportTransToJson(locale, transPath, pluralType)
+      const fresh = await exportTransToJson(locale, transPath, pluralType)
       const jsonPath = path.join(targetDir, locale + '.json')
+      let finalJson: JsonTrans = fresh
+      if (mergeKeys != null) {
+        const base = await readJsonDirBase(jsonPath, useLocaleKey, locale)
+        finalJson = mergeJsonTrans(base, fresh, mergeKeys, pluralType)
+      }
       if (useLocaleKey) {
-        await fsp.writeFile(jsonPath, JSON.stringify({ [locale]: json }, null, 2))
+        await fsp.writeFile(jsonPath, JSON.stringify({ [locale]: finalJson }, null, 2))
       } else {
-        await fsp.writeFile(jsonPath, JSON.stringify(json, null, 2))
+        await fsp.writeFile(jsonPath, JSON.stringify(finalJson, null, 2))
       }
     }
   }
@@ -80,6 +120,83 @@ export function buildJsonTrans(locale: string, transEntries: TransEntry[], plura
     }
   }
   return json
+}
+
+const I18NEXT_PLURAL_SUFFIX_RE = /_(zero|one|two|few|many|other)$/
+
+/**
+ * Returns true if `jsonKey` falls within the scope of any keyName in `mergeKeys`,
+ * accounting for plural-form key shapes used by each pluralType.
+ *
+ * @internal exported for testing
+ */
+export function jsonKeyMatchesMergeKeys(
+  jsonKey: string,
+  mergeKeys: Set<string>,
+  pluralType?: JsonPluralType,
+): boolean {
+  if (mergeKeys.has(jsonKey)) {
+    return true
+  }
+  if (pluralType === 'i18next') {
+    const m = jsonKey.match(I18NEXT_PLURAL_SUFFIX_RE)
+    if (m) {
+      const base = jsonKey.substring(0, m.index!)
+      return mergeKeys.has(base)
+    }
+  }
+  return false
+}
+
+/**
+ * Merge `fresh` (output for PR-N keys only) into `base` (existing output) such that
+ * keys in `mergeKeys` are taken from `fresh` and all other keys are preserved.
+ *
+ * @internal exported for testing
+ */
+export function mergeJsonTrans(
+  base: JsonTrans,
+  fresh: JsonTrans,
+  mergeKeys: Set<string>,
+  pluralType?: JsonPluralType,
+): JsonTrans {
+  const result: JsonTrans = { ...base }
+  for (const key of Object.keys(result)) {
+    if (jsonKeyMatchesMergeKeys(key, mergeKeys, pluralType)) {
+      delete result[key]
+    }
+  }
+  for (const [key, value] of Object.entries(fresh)) {
+    result[key] = value
+  }
+  return result
+}
+
+async function readJsonIfExists(filePath: string): Promise<unknown | null> {
+  try {
+    const text = await fsp.readFile(filePath, { encoding: 'utf-8' })
+    return JSON.parse(text)
+  } catch (err) {
+    if (isErrnoException(err, 'ENOENT')) {
+      return null
+    }
+    throw err
+  }
+}
+
+async function readJsonDirBase(jsonPath: string, useLocaleKey: boolean, locale: string): Promise<JsonTrans> {
+  const parsed = await readJsonIfExists(jsonPath)
+  if (parsed == null) {
+    return {}
+  }
+  if (useLocaleKey) {
+    const inner = (parsed as { [locale: string]: unknown })[locale]
+    if (inner == null || typeof inner !== 'object') {
+      return {}
+    }
+    return inner as JsonTrans
+  }
+  return parsed as JsonTrans
 }
 
 async function exportTransToJson(locale: string, transPath: string, pluralType?: JsonPluralType): Promise<JsonTrans> {

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -1,7 +1,8 @@
 import type { DomainConfig } from './config.js'
+import type { CompileOptions } from './plugin-types.js'
 import { pluginRegistry } from './plugin-registry.js'
 
-export type { CompilerFunc } from './plugin-types.js'
+export type { CompileOptions, CompilerFunc } from './plugin-types.js'
 
 /**
  * Compile translations for all configured output formats.
@@ -9,8 +10,14 @@ export type { CompilerFunc } from './plugin-types.js'
  * @param domainName - The domain identifier
  * @param domainConfig - Configuration object describing the domain
  * @param transDir - Directory containing translation files
+ * @param options - Optional compiler options (e.g., {@link CompileOptions.mergeKeys})
  */
-export async function compileAll(domainName: string, domainConfig: DomainConfig, transDir: string) {
+export async function compileAll(
+  domainName: string,
+  domainConfig: DomainConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
   const configs = domainConfig.getCompilerConfigs()
   for (const config of configs) {
     const type = config.getType()
@@ -24,6 +31,6 @@ export async function compileAll(domainName: string, domainConfig: DomainConfig,
       throw new Error(`No compiler found for type: ${type}${installHint}`)
     }
 
-    await compiler(domainName, config, transDir)
+    await compiler(domainName, config, transDir, options)
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export type {
   ExtractorFunc,
   CompilerPlugin,
   CompilerFunc,
+  CompileOptions,
   SyncerPlugin,
   SyncerFunc,
   SyncerOptions,

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -22,6 +22,19 @@ export interface ExtractorPlugin {
 }
 
 /**
+ * Options that may be passed to a compiler invocation.
+ */
+export interface CompileOptions {
+  /**
+   * When set, the compiler must update only the entries whose keyName is in the set
+   * and preserve any other entries that already exist in the output. An empty set
+   * means "no entries to update" — the compiler must leave existing outputs untouched.
+   * If not set, the compiler performs a full overwrite of the output (default behavior).
+   */
+  mergeKeys?: Set<string>,
+}
+
+/**
  * Compiler function signature
  * Compiles translations to platform-specific formats
  */
@@ -29,6 +42,7 @@ export type CompilerFunc = (
   domainName: string,
   config: CompilerConfig,
   transDir: string,
+  options?: CompileOptions,
 ) => Promise<void>
 
 /**

--- a/packages/plugin-android/src/compiler.test.ts
+++ b/packages/plugin-android/src/compiler.test.ts
@@ -194,7 +194,7 @@ describe('android compiler test', () => {
     })
   })
 
-  describe('mergeKeys mode', () => {
+  describe('merge mode', () => {
     it('updates only PR-N entry and preserves other entries from dstXml', async () => {
       // PR-N has only 'drop'; src has both 'keep' and 'drop'.
       const transEntries: TransEntry[] = [
@@ -216,9 +216,7 @@ describe('android compiler test', () => {
     <string name="drop">NEW</string>
 </resources>`
 
-      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
-        mergeKeys: new Set(['Old']),
-      })
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
       assert.equal(newDstXml, targetXml)
     })
 
@@ -237,9 +235,7 @@ describe('android compiler test', () => {
     <string name="drop">기존낡음</string>
 </resources>`
 
-      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
-        mergeKeys: new Set(['Old']),
-      })
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
       assert.match(newDstXml, /<string name="keep">기존유지<\/string>/)
       assert.equal(/<string name="drop">/.test(newDstXml), false)
     })
@@ -262,9 +258,7 @@ describe('android compiler test', () => {
     <string name="other">기존다른</string>
 </resources>`
 
-      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
-        mergeKeys: new Set(['Unrelated']),
-      })
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
       assert.equal(newDstXml, targetXml)
     })
 
@@ -281,16 +275,10 @@ describe('android compiler test', () => {
 <resources>
     <string name="keep">기존유지</string>
 </resources>`
-      const targetXml = `<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="keep">기존유지</string>
-    <string name="newly_added">신규</string>
-</resources>`
 
-      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
-        mergeKeys: new Set(['NewSrc']),
-      })
-      assert.equal(newDstXml, targetXml)
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
+      assert.match(newDstXml, /<string name="keep">기존유지<\/string>/)
+      assert.match(newDstXml, /<string name="newly_added">신규<\/string>/)
     })
 
     it('updates a PR-N plurals entry and preserves other plurals from dst', async () => {
@@ -319,9 +307,7 @@ describe('android compiler test', () => {
         <item quantity="other">%d 다른들 OLD</item>
     </plurals>
 </resources>`
-      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
-        mergeKeys: new Set(['%d item']),
-      })
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
       // `item_plurals` updated to NEW values; `other_plurals` preserved as OLD.
       assert.match(newDstXml, /%d 항목 NEW/)
       assert.match(newDstXml, /%d 항목들 NEW/)
@@ -329,6 +315,39 @@ describe('android compiler test', () => {
       assert.match(newDstXml, /%d 다른들 OLD/)
       // No leak of source default text.
       assert.equal(/%d items?</.test(newDstXml), false)
+    })
+
+    it('preserves dst ordering and entries that do not exist in src', async () => {
+      // Regression for: merge mode used to rebuild from srcXml, which would reorder
+      // (and drop) any dst-only entries when src and dst diverged. dst-only entries
+      // and ordering must survive.
+      const transEntries: TransEntry[] = [
+        { context: 'b_key', key: 'B', messages: { other: 'B-NEW' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="a_key">A</string>
+    <string name="b_key">B</string>
+</resources>`
+      // Note: dst orders b_key first, has c_key only (not in src), and lacks a_key entirely.
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="b_key">B-OLD</string>
+    <string name="c_key">C-OLD</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
+
+      const bIdx = newDstXml.indexOf('name="b_key"')
+      const cIdx = newDstXml.indexOf('name="c_key"')
+      assert.notEqual(bIdx, -1)
+      assert.notEqual(cIdx, -1)
+      // dst ordering preserved: b_key still before c_key.
+      assert.ok(bIdx < cIdx, 'expected b_key to remain before c_key in merge output')
+      // b_key updated, c_key (dst-only) preserved, a_key (src-only without trans) absent.
+      assert.match(newDstXml, /<string name="b_key">B-NEW<\/string>/)
+      assert.match(newDstXml, /<string name="c_key">C-OLD<\/string>/)
+      assert.equal(newDstXml.includes('name="a_key"'), false)
     })
   })
 })

--- a/packages/plugin-android/src/compiler.test.ts
+++ b/packages/plugin-android/src/compiler.test.ts
@@ -193,4 +193,142 @@ describe('android compiler test', () => {
       assert.equal(newDstXml, targetXml)
     })
   })
+
+  describe('mergeKeys mode', () => {
+    it('updates only PR-N entry and preserves other entries from dstXml', async () => {
+      // PR-N has only 'drop'; src has both 'keep' and 'drop'.
+      const transEntries: TransEntry[] = [
+        { context: 'drop', key: 'Old', messages: { other: 'NEW' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">Keep</string>
+    <string name="drop">Old</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="drop">기존낡음</string>
+</resources>`
+      const targetXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="drop">NEW</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
+        mergeKeys: new Set(['Old']),
+      })
+      assert.equal(newDstXml, targetXml)
+    })
+
+    it('removes a PR-N entry from dst when its translation is empty', async () => {
+      const transEntries: TransEntry[] = [
+        { context: 'drop', key: 'Old', messages: {}, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">Keep</string>
+    <string name="drop">Old</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="drop">기존낡음</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
+        mergeKeys: new Set(['Old']),
+      })
+      assert.match(newDstXml, /<string name="keep">기존유지<\/string>/)
+      assert.equal(/<string name="drop">/.test(newDstXml), false)
+    })
+
+    it('returns dst-only translations untouched when no PR-N keys belong to this xml', async () => {
+      const transEntries: TransEntry[] = []
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">Keep</string>
+    <string name="other">Other</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="other">기존다른</string>
+</resources>`
+      const targetXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="other">기존다른</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
+        mergeKeys: new Set(['Unrelated']),
+      })
+      assert.equal(newDstXml, targetXml)
+    })
+
+    it('adds a PR-N entry that does not yet exist in dst', async () => {
+      const transEntries: TransEntry[] = [
+        { context: 'newly_added', key: 'NewSrc', messages: { other: '신규' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">Keep</string>
+    <string name="newly_added">NewSrc</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+</resources>`
+      const targetXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="keep">기존유지</string>
+    <string name="newly_added">신규</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
+        mergeKeys: new Set(['NewSrc']),
+      })
+      assert.equal(newDstXml, targetXml)
+    })
+
+    it('updates a PR-N plurals entry and preserves other plurals from dst', async () => {
+      const transEntries: TransEntry[] = [
+        { context: 'item_plurals', key: '%d item', messages: { one: '%d 항목 NEW', other: '%d 항목들 NEW' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="item_plurals">
+        <item quantity="one">%d item</item>
+        <item quantity="other">%d items</item>
+    </plurals>
+    <plurals name="other_plurals">
+        <item quantity="one">%d other</item>
+        <item quantity="other">%d others</item>
+    </plurals>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="item_plurals">
+        <item quantity="one">%d 항목 OLD</item>
+        <item quantity="other">%d 항목들 OLD</item>
+    </plurals>
+    <plurals name="other_plurals">
+        <item quantity="one">%d 다른 OLD</item>
+        <item quantity="other">%d 다른들 OLD</item>
+    </plurals>
+</resources>`
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, {
+        mergeKeys: new Set(['%d item']),
+      })
+      // `item_plurals` updated to NEW values; `other_plurals` preserved as OLD.
+      assert.match(newDstXml, /%d 항목 NEW/)
+      assert.match(newDstXml, /%d 항목들 NEW/)
+      assert.match(newDstXml, /%d 다른 OLD/)
+      assert.match(newDstXml, /%d 다른들 OLD/)
+      // No leak of source default text.
+      assert.equal(/%d items?</.test(newDstXml), false)
+    })
+  })
 })

--- a/packages/plugin-android/src/compiler.ts
+++ b/packages/plugin-android/src/compiler.ts
@@ -41,19 +41,20 @@ export async function compileToAndroidXml(
   if (mergeKeys != null && mergeKeys.size === 0) {
     return
   }
+  const isMerge = mergeKeys != null
 
   const modules = config.getModules()
 
   if (modules.length > 0) {
     // Multi-module mode
-    await compileMultiModule(modules, config, transDir, mergeKeys)
+    await compileMultiModule(modules, config, transDir, isMerge)
   } else {
     // Single res-dir mode (backward compatibility)
-    await compileSingleResDir(config, transDir, mergeKeys)
+    await compileSingleResDir(config, transDir, isMerge)
   }
 }
 
-async function compileSingleResDir(config: CompilerConfig, transDir: string, mergeKeys?: Set<string>) {
+async function compileSingleResDir(config: CompilerConfig, transDir: string, isMerge: boolean) {
   const resDir = config.getResDir()
   const defaultLocale = config.getDefaultLocale()
   log.info('compile', `generating res files '${resDir}/values-{locale}/strings.xml'`)
@@ -73,12 +74,12 @@ async function compileSingleResDir(config: CompilerConfig, transDir: string, mer
     const locale = extractLocaleFromTransPath(transPath)
     if (locale === defaultLocale) {
       // The default locale's xml is the source itself; in merge mode, do not rewrite it.
-      if (mergeKeys != null) continue
+      if (isMerge) continue
       await writeXml(buildAndroidXml(builder, srcXmlJson), resDir, null)
     } else {
       const transEntries = await readTransEntries(transPath)
       const dstXml = await readXml(resDir, locale, '<?xml version="1.0" encoding="utf-8"?>\n<resources></resources>')
-      const newDstXml = await generateAndroidXml(locale, transEntries, srcXml, dstXml, { mergeKeys })
+      const newDstXml = await generateAndroidXml(locale, transEntries, srcXml, dstXml, { merge: isMerge })
       await writeXml(newDstXml, resDir, locale)
     }
   }
@@ -88,7 +89,7 @@ async function compileMultiModule(
   modules: string[],
   config: CompilerConfig,
   transDir: string,
-  mergeKeys?: Set<string>,
+  isMerge: boolean,
 ) {
   const defaultLocale = config.getDefaultLocale()
   const defaultModule = config.getDefaultModule()
@@ -124,14 +125,14 @@ async function compileMultiModule(
     for (const transPath of transPaths) {
       const locale = extractLocaleFromTransPath(transPath)
       if (locale === defaultLocale) {
-        if (mergeKeys != null) continue
+        if (isMerge) continue
         await writeXml(buildAndroidXml(builder, srcXmlJson), resDir, null)
       } else {
         const transEntries = await readTransEntries(transPath)
         // Filter entries for this module
         const moduleTransEntries = filterTransEntriesForModule(transEntries, module, defaultModule)
         const dstXml = await readXml(resDir, locale, '<?xml version="1.0" encoding="utf-8"?>\n<resources></resources>')
-        const newDstXml = await generateAndroidXml(locale, moduleTransEntries, srcXml, dstXml, { mergeKeys })
+        const newDstXml = await generateAndroidXml(locale, moduleTransEntries, srcXml, dstXml, { merge: isMerge })
         await writeXml(newDstXml, resDir, locale)
       }
     }
@@ -157,13 +158,13 @@ export function filterTransEntriesForModule(transEntries: TransEntry[], module: 
 
 export interface GenerateAndroidXmlOptions {
   /**
-   * When set, only string/plurals entries that resolve to a translation in `transEntries`
-   * are updated; all other entries are taken from `dstXml` as-is. The contents of the set
-   * itself are not consulted directly (PR-N membership is implicit in `transEntries`).
-   *
-   * The presence of this option flips compileSingleResDir/compileMultiModule into "merge mode".
+   * When true, the output is produced by patching `dstXml` in place: only the
+   * string/plurals entries that correspond to a `transEntry` are added/updated/removed,
+   * and every other entry in `dstXml` (including its order) is preserved as-is.
+   * When false (default), the output is rebuilt from `srcXml` as the authoritative
+   * structure — every entry of dstXml is replaced.
    */
-  mergeKeys?: Set<string>,
+  merge?: boolean,
 }
 
 export async function generateAndroidXml(
@@ -188,13 +189,23 @@ export async function generateAndroidXml(
     throw new Error('no resources tag')
   }
 
-  const trans = EntryCollection.loadEntries(transEntries)
-  const isMerge = options?.mergeKeys != null
-  const dstNodesByName = isMerge ? indexResourcesByName(dstResNode.resources as XMLNode[]) : null
+  if (options?.merge) {
+    return patchAndroidXmlMerge(transEntries, resNode, dstResNode, dstXmlJson, builder)
+  }
+  return rebuildAndroidXml(transEntries, resNode, dstResNode, dstXmlJson, builder)
+}
 
+function rebuildAndroidXml(
+  transEntries: TransEntry[],
+  srcResNode: XMLTagNode,
+  dstResNode: XMLTagNode,
+  dstXmlJson: ReturnType<typeof parseAndroidXml>,
+  builder: ReturnType<typeof getAndroidXmlBuilder>,
+): string {
+  const trans = EntryCollection.loadEntries(transEntries)
   const dstResources: XMLNode[] = []
   let passingText = false
-  for (const node of resNode.resources) {
+  for (const node of srcResNode.resources) {
     if (isTextNode(node)) {
       if (passingText) {
         passingText = false
@@ -204,7 +215,6 @@ export async function generateAndroidXml(
       continue
     }
 
-    // string 태그
     if (isTagNode(node, 'string')) {
       // translatable="false" 인 태그는 스킵
       const translatable = getAttrValue(node, 'translatable')
@@ -212,94 +222,49 @@ export async function generateAndroidXml(
         passingText = true
         continue
       }
-
-      // name attr 없는 태그는 문제가 있는 것인데, 일단 스킵
       const name = getAttrValue(node, 'name')
       if (name == null) {
         passingText = true
         continue
       }
-
-      // 번역이 없는 태그도 스킵 (merge 모드에선 dstXml에서 보존)
       const transEntry = trans.find(name, null)
       if (transEntry == null) {
-        if (preserveFromDst(name, dstNodesByName, 'string', dstResources)) {
-          continue
-        }
         passingText = true
         continue
       }
       const value = transEntry.messages.other
       if (!value) {
-        // PR-N key with no translation: drop from output (do not preserve from dst).
         passingText = true
         continue
       }
-
       const valueNode = createValueNode(node, node.string, value)
       dstResources.push({ ...node, string: [valueNode] })
     } else if (isTagNode(node, 'plurals')) {
-      // translatable="false" 인 태그는 스킵
       const translatable = getAttrValue(node, 'translatable')
       if (translatable == 'false') {
         passingText = true
         continue
       }
-
-      // name attr 없는 태그는 문제가 있는 것인데, 일단 스킵
       const name = getAttrValue(node, 'name')
       if (name == null) {
         passingText = true
         continue
       }
-
-      // 번역이 없는 태그도 스킵 (merge 모드에선 dstXml에서 보존)
       const transEntry = trans.find(name, null)
       if (transEntry == null) {
-        if (preserveFromDst(name, dstNodesByName, 'plurals', dstResources)) {
-          continue
-        }
         passingText = true
         continue
       }
-      const values = transEntry.messages
-      if (Object.keys(values).length == 0) {
-        // PR-N key with no translation: drop from output (do not preserve from dst).
+      if (Object.keys(transEntry.messages).length == 0) {
         passingText = true
         continue
       }
-
-      let plFirstTextNode: XMLTextNode | null = null
-      let plLastTextNode: XMLTextNode | null = null
-      const plurals = (node as XMLTagNode).plurals
-      if (isTextNode(plurals[0])) {
-        plFirstTextNode = plurals[0]
-      }
-      if (isTextNode(plurals[plurals.length - 1])) {
-        plLastTextNode = plurals[plurals.length - 1] as XMLTextNode
-      }
-
-      let itemNode = findFirstTagNode(plurals, 'item', { quantity: 'other' })
-      if (itemNode == null) {
-        itemNode = findFirstTagNode(plurals, 'item')
-      }
-      if (itemNode == null) {
+      const pluralsNode = buildPluralsNode(node, transEntry.messages)
+      if (pluralsNode == null) {
         passingText = true
         continue
       }
-
-      const dstPlurals: XMLNode[] = []
-      for (const [key, value] of Object.entries(transEntry.messages)) {
-        if (plFirstTextNode != null) {
-          dstPlurals.push({ ...plFirstTextNode })
-        }
-        const valueNode = createValueNode(itemNode, itemNode.item, value)
-        dstPlurals.push({ ...itemNode, 'item': [valueNode], ':@': { '@_quantity': key } })
-      }
-      if (plLastTextNode != null) {
-        dstPlurals.push({ ...plLastTextNode })
-      }
-      dstResources.push({ ...node, plurals: dstPlurals })
+      dstResources.push(pluralsNode)
     } else {
       dstResources.push(node)
     }
@@ -307,6 +272,85 @@ export async function generateAndroidXml(
 
   dstResNode.resources = dstResources
   return buildAndroidXml(builder, dstXmlJson)
+}
+
+function patchAndroidXmlMerge(
+  transEntries: TransEntry[],
+  srcResNode: XMLTagNode,
+  dstResNode: XMLTagNode,
+  dstXmlJson: ReturnType<typeof parseAndroidXml>,
+  builder: ReturnType<typeof getAndroidXmlBuilder>,
+): string {
+  const srcNodesByName = indexResourcesByName(srcResNode.resources as XMLNode[])
+  const dstResources = [...dstResNode.resources as XMLNode[]]
+
+  for (const transEntry of transEntries) {
+    const name = transEntry.context
+    if (name == null) continue
+
+    const srcNode = srcNodesByName.get(name)
+    if (srcNode == null) {
+      // PR-scope key not found in default values — drop it from dst as well.
+      removeFromResourcesByName(dstResources, name)
+      continue
+    }
+
+    if (isTagNode(srcNode, 'string')) {
+      const translatable = getAttrValue(srcNode, 'translatable')
+      if (translatable === 'false') continue
+      const value = transEntry.messages.other
+      if (!value) {
+        removeFromResourcesByName(dstResources, name)
+        continue
+      }
+      const newNode = { ...srcNode, string: [createValueNode(srcNode, srcNode.string, value)] }
+      replaceOrAppendByName(dstResources, name, newNode)
+    } else if (isTagNode(srcNode, 'plurals')) {
+      const translatable = getAttrValue(srcNode, 'translatable')
+      if (translatable === 'false') continue
+      if (Object.keys(transEntry.messages).length == 0) {
+        removeFromResourcesByName(dstResources, name)
+        continue
+      }
+      const pluralsNode = buildPluralsNode(srcNode, transEntry.messages)
+      if (pluralsNode == null) continue
+      replaceOrAppendByName(dstResources, name, pluralsNode)
+    }
+  }
+
+  dstResNode.resources = dstResources
+  return buildAndroidXml(builder, dstXmlJson)
+}
+
+function buildPluralsNode(srcNode: XMLTagNode, messages: TransEntry['messages']): XMLTagNode | null {
+  let plFirstTextNode: XMLTextNode | null = null
+  let plLastTextNode: XMLTextNode | null = null
+  const plurals = srcNode.plurals
+  if (isTextNode(plurals[0])) {
+    plFirstTextNode = plurals[0]
+  }
+  if (isTextNode(plurals[plurals.length - 1])) {
+    plLastTextNode = plurals[plurals.length - 1] as XMLTextNode
+  }
+
+  let itemNode = findFirstTagNode(plurals, 'item', { quantity: 'other' })
+  if (itemNode == null) {
+    itemNode = findFirstTagNode(plurals, 'item')
+  }
+  if (itemNode == null) return null
+
+  const dstPlurals: XMLNode[] = []
+  for (const [key, value] of Object.entries(messages)) {
+    if (plFirstTextNode != null) {
+      dstPlurals.push({ ...plFirstTextNode })
+    }
+    const valueNode = createValueNode(itemNode, itemNode.item, value)
+    dstPlurals.push({ ...itemNode, 'item': [valueNode], ':@': { '@_quantity': key } })
+  }
+  if (plLastTextNode != null) {
+    dstPlurals.push({ ...plLastTextNode })
+  }
+  return { ...srcNode, plurals: dstPlurals }
 }
 
 function indexResourcesByName(resources: XMLNode[]): Map<string, XMLTagNode> {
@@ -321,18 +365,35 @@ function indexResourcesByName(resources: XMLNode[]): Map<string, XMLTagNode> {
   return map
 }
 
-function preserveFromDst(
-  name: string,
-  dstNodesByName: Map<string, XMLTagNode> | null,
-  expectedTag: 'string' | 'plurals',
-  out: XMLNode[],
-): boolean {
-  if (dstNodesByName == null) return false
-  const existing = dstNodesByName.get(name)
-  if (existing == null) return false
-  if (!isTagNode(existing, expectedTag)) return false
-  out.push({ ...existing })
-  return true
+function findIndexByName(resources: XMLNode[], name: string): number {
+  for (let i = 0; i < resources.length; i++) {
+    const node = resources[i]
+    if (isTextNode(node)) continue
+    if (!isTagNode(node, 'string') && !isTagNode(node, 'plurals')) continue
+    if (getAttrValue(node, 'name') === name) return i
+  }
+  return -1
+}
+
+function replaceOrAppendByName(resources: XMLNode[], name: string, newNode: XMLTagNode): void {
+  const idx = findIndexByName(resources, name)
+  if (idx >= 0) {
+    resources[idx] = newNode
+    return
+  }
+  resources.push(newNode)
+}
+
+function removeFromResourcesByName(resources: XMLNode[], name: string): void {
+  const idx = findIndexByName(resources, name)
+  if (idx < 0) return
+  // Also drop the immediately preceding text node (typically indentation/newline)
+  // so we don't leave a dangling whitespace-only line where the entry was.
+  if (idx > 0 && isTextNode(resources[idx - 1])) {
+    resources.splice(idx - 1, 2)
+  } else {
+    resources.splice(idx, 1)
+  }
 }
 
 function createValueNode(node: XMLTagNode, children: XMLNode[], value: string) {

--- a/packages/plugin-android/src/compiler.ts
+++ b/packages/plugin-android/src/compiler.ts
@@ -2,6 +2,7 @@ import fsp from 'node:fs/promises'
 import log from 'npmlog'
 import * as path from 'path'
 import {
+  type CompileOptions,
   type CompilerConfig,
   EntryCollection,
   extractLocaleFromTransPath,
@@ -30,19 +31,29 @@ import {
 } from './android-xml-utils.js'
 import { getModuleName, isDefaultModule } from './extractor.js'
 
-export async function compileToAndroidXml(domainName: string, config: CompilerConfig, transDir: string) {
+export async function compileToAndroidXml(
+  domainName: string,
+  config: CompilerConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
+  const mergeKeys = options?.mergeKeys
+  if (mergeKeys != null && mergeKeys.size === 0) {
+    return
+  }
+
   const modules = config.getModules()
 
   if (modules.length > 0) {
     // Multi-module mode
-    await compileMultiModule(modules, config, transDir)
+    await compileMultiModule(modules, config, transDir, mergeKeys)
   } else {
     // Single res-dir mode (backward compatibility)
-    await compileSingleResDir(config, transDir)
+    await compileSingleResDir(config, transDir, mergeKeys)
   }
 }
 
-async function compileSingleResDir(config: CompilerConfig, transDir: string) {
+async function compileSingleResDir(config: CompilerConfig, transDir: string, mergeKeys?: Set<string>) {
   const resDir = config.getResDir()
   const defaultLocale = config.getDefaultLocale()
   log.info('compile', `generating res files '${resDir}/values-{locale}/strings.xml'`)
@@ -61,17 +72,24 @@ async function compileSingleResDir(config: CompilerConfig, transDir: string) {
   for (const transPath of transPaths) {
     const locale = extractLocaleFromTransPath(transPath)
     if (locale === defaultLocale) {
+      // The default locale's xml is the source itself; in merge mode, do not rewrite it.
+      if (mergeKeys != null) continue
       await writeXml(buildAndroidXml(builder, srcXmlJson), resDir, null)
     } else {
       const transEntries = await readTransEntries(transPath)
       const dstXml = await readXml(resDir, locale, '<?xml version="1.0" encoding="utf-8"?>\n<resources></resources>')
-      const newDstXml = await generateAndroidXml(locale, transEntries, srcXml, dstXml)
+      const newDstXml = await generateAndroidXml(locale, transEntries, srcXml, dstXml, { mergeKeys })
       await writeXml(newDstXml, resDir, locale)
     }
   }
 }
 
-async function compileMultiModule(modules: string[], config: CompilerConfig, transDir: string) {
+async function compileMultiModule(
+  modules: string[],
+  config: CompilerConfig,
+  transDir: string,
+  mergeKeys?: Set<string>,
+) {
   const defaultLocale = config.getDefaultLocale()
   const defaultModule = config.getDefaultModule()
   log.info('compile', `generating res files for ${modules.length} modules`)
@@ -106,13 +124,14 @@ async function compileMultiModule(modules: string[], config: CompilerConfig, tra
     for (const transPath of transPaths) {
       const locale = extractLocaleFromTransPath(transPath)
       if (locale === defaultLocale) {
+        if (mergeKeys != null) continue
         await writeXml(buildAndroidXml(builder, srcXmlJson), resDir, null)
       } else {
         const transEntries = await readTransEntries(transPath)
         // Filter entries for this module
         const moduleTransEntries = filterTransEntriesForModule(transEntries, module, defaultModule)
         const dstXml = await readXml(resDir, locale, '<?xml version="1.0" encoding="utf-8"?>\n<resources></resources>')
-        const newDstXml = await generateAndroidXml(locale, moduleTransEntries, srcXml, dstXml)
+        const newDstXml = await generateAndroidXml(locale, moduleTransEntries, srcXml, dstXml, { mergeKeys })
         await writeXml(newDstXml, resDir, locale)
       }
     }
@@ -136,7 +155,24 @@ export function filterTransEntriesForModule(transEntries: TransEntry[], module: 
     }))
 }
 
-export async function generateAndroidXml(locale: string, transEntries: TransEntry[], srcXml: string, dstXml: string) {
+export interface GenerateAndroidXmlOptions {
+  /**
+   * When set, only string/plurals entries that resolve to a translation in `transEntries`
+   * are updated; all other entries are taken from `dstXml` as-is. The contents of the set
+   * itself are not consulted directly (PR-N membership is implicit in `transEntries`).
+   *
+   * The presence of this option flips compileSingleResDir/compileMultiModule into "merge mode".
+   */
+  mergeKeys?: Set<string>,
+}
+
+export async function generateAndroidXml(
+  locale: string,
+  transEntries: TransEntry[],
+  srcXml: string,
+  dstXml: string,
+  options?: GenerateAndroidXmlOptions,
+) {
   const parser = getAndroidXmlParser()
   const builder = getAndroidXmlBuilder()
 
@@ -153,6 +189,8 @@ export async function generateAndroidXml(locale: string, transEntries: TransEntr
   }
 
   const trans = EntryCollection.loadEntries(transEntries)
+  const isMerge = options?.mergeKeys != null
+  const dstNodesByName = isMerge ? indexResourcesByName(dstResNode.resources as XMLNode[]) : null
 
   const dstResources: XMLNode[] = []
   let passingText = false
@@ -182,14 +220,18 @@ export async function generateAndroidXml(locale: string, transEntries: TransEntr
         continue
       }
 
-      // 번역이 없는 태그도 스킵
+      // 번역이 없는 태그도 스킵 (merge 모드에선 dstXml에서 보존)
       const transEntry = trans.find(name, null)
       if (transEntry == null) {
+        if (preserveFromDst(name, dstNodesByName, 'string', dstResources)) {
+          continue
+        }
         passingText = true
         continue
       }
       const value = transEntry.messages.other
       if (!value) {
+        // PR-N key with no translation: drop from output (do not preserve from dst).
         passingText = true
         continue
       }
@@ -211,14 +253,18 @@ export async function generateAndroidXml(locale: string, transEntries: TransEntr
         continue
       }
 
-      // 번역이 없는 태그도 스킵
+      // 번역이 없는 태그도 스킵 (merge 모드에선 dstXml에서 보존)
       const transEntry = trans.find(name, null)
       if (transEntry == null) {
+        if (preserveFromDst(name, dstNodesByName, 'plurals', dstResources)) {
+          continue
+        }
         passingText = true
         continue
       }
       const values = transEntry.messages
       if (Object.keys(values).length == 0) {
+        // PR-N key with no translation: drop from output (do not preserve from dst).
         passingText = true
         continue
       }
@@ -261,6 +307,32 @@ export async function generateAndroidXml(locale: string, transEntries: TransEntr
 
   dstResNode.resources = dstResources
   return buildAndroidXml(builder, dstXmlJson)
+}
+
+function indexResourcesByName(resources: XMLNode[]): Map<string, XMLTagNode> {
+  const map = new Map<string, XMLTagNode>()
+  for (const node of resources) {
+    if (isTextNode(node)) continue
+    if (!isTagNode(node, 'string') && !isTagNode(node, 'plurals')) continue
+    const name = getAttrValue(node, 'name')
+    if (name == null) continue
+    map.set(name, node)
+  }
+  return map
+}
+
+function preserveFromDst(
+  name: string,
+  dstNodesByName: Map<string, XMLTagNode> | null,
+  expectedTag: 'string' | 'plurals',
+  out: XMLNode[],
+): boolean {
+  if (dstNodesByName == null) return false
+  const existing = dstNodesByName.get(name)
+  if (existing == null) return false
+  if (!isTagNode(existing, expectedTag)) return false
+  out.push({ ...existing })
+  return true
 }
 
 function createValueNode(node: XMLTagNode, children: XMLNode[], value: string) {

--- a/packages/plugin-android/src/compiler.ts
+++ b/packages/plugin-android/src/compiler.ts
@@ -131,6 +131,10 @@ async function compileMultiModule(
         const transEntries = await readTransEntries(transPath)
         // Filter entries for this module
         const moduleTransEntries = filterTransEntriesForModule(transEntries, module, defaultModule)
+        // In merge mode, skip module/locale combinations with no PR-scope entries —
+        // otherwise an empty fallback XML would be written to a missing locale file,
+        // creating a brand-new values-{locale}/strings.xml unrelated to the PR scope.
+        if (isMerge && moduleTransEntries.length === 0) continue
         const dstXml = await readXml(resDir, locale, '<?xml version="1.0" encoding="utf-8"?>\n<resources></resources>')
         const newDstXml = await generateAndroidXml(locale, moduleTransEntries, srcXml, dstXml, { merge: isMerge })
         await writeXml(newDstXml, resDir, locale)

--- a/packages/plugin-ios/src/compiler.test.ts
+++ b/packages/plugin-ios/src/compiler.test.ts
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { generateStringsFile, transformIosPluralMessages } from './compiler.js'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import i18nStringsFiles from 'i18n-strings-files'
+import { CompilerConfig, type TransEntry, writeTransEntries } from 'l10n-tools-core'
+import { compileToIosStrings, generateStringsFile, shouldProcessKey, transformIosPluralMessages } from './compiler.js'
 
 describe('generateStringsFile', () => {
   it('emits a "msgid" = "msgstr"; pair for plain string values', () => {
@@ -66,5 +71,162 @@ describe('transformIosPluralMessages', () => {
       () => transformIosPluralMessages('ko', 'apple', { other: 'apples' }),
       /\[ko\] "other" of "apple"/,
     )
+  })
+})
+
+describe('shouldProcessKey', () => {
+  const transEntries: TransEntry[] = [
+    { context: 'NSCameraUsageDescription', key: 'Need camera', messages: { other: '카메라' }, flag: null },
+    { context: null, key: 'Hello', messages: { other: '안녕' }, flag: null },
+  ]
+
+  it('always processes keys when mergeKeys is undefined', () => {
+    assert.equal(shouldProcessKey('AnyKey', transEntries, undefined), true)
+  })
+
+  it('matches by context when entry has a context', () => {
+    assert.equal(shouldProcessKey('NSCameraUsageDescription', transEntries, new Set(['Need camera'])), true)
+  })
+
+  it('matches by key when entry has no context', () => {
+    assert.equal(shouldProcessKey('Hello', transEntries, new Set(['Hello'])), true)
+  })
+
+  it('returns false when no trans entry corresponds to the key', () => {
+    assert.equal(shouldProcessKey('UnrelatedKey', transEntries, new Set(['Need camera', 'Hello'])), false)
+  })
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return await fsp.mkdtemp(path.join(os.tmpdir(), prefix))
+}
+
+function makeIosConfig(srcDir: string): CompilerConfig {
+  return new CompilerConfig({ 'type': 'ios', 'src-dir': srcDir } as never)
+}
+
+async function writeTransFiles(dir: string, perLocale: { [locale: string]: TransEntry[] }): Promise<void> {
+  for (const [locale, entries] of Object.entries(perLocale)) {
+    await writeTransEntries(path.join(dir, `trans-${locale}.json`), entries)
+  }
+}
+
+describe('compileToIosStrings InfoPlist with mergeKeys', () => {
+  it('updates only PR-N InfoPlist entry, preserving others', async () => {
+    const dir = await makeTempDir('compile-ios-merge-')
+    try {
+      const srcDir = path.join(dir, 'src')
+      const transDir = path.join(dir, 'trans')
+      const lprojDir = path.join(srcDir, 'ko.lproj')
+      await fsp.mkdir(lprojDir, { recursive: true })
+      await fsp.mkdir(transDir)
+      const stringsPath = path.join(lprojDir, 'InfoPlist.strings')
+
+      // Base output: two keys translated.
+      await fsp.writeFile(stringsPath,
+        '\n"NSCameraUsageDescription" = "기존카메라";\n' +
+        '\n"NSMicrophoneUsageDescription" = "기존마이크";\n',
+        { encoding: 'utf-8' },
+      )
+
+      // PR-N has only NSCameraUsageDescription.
+      await writeTransFiles(transDir, {
+        ko: [{ context: 'NSCameraUsageDescription', key: 'Camera', messages: { other: '새카메라' }, flag: null }],
+      })
+
+      await compileToIosStrings('d', makeIosConfig(srcDir), transDir, {
+        mergeKeys: new Set(['Camera']),
+      })
+
+      const after = i18nStringsFiles.readFileSync(stringsPath, { encoding: 'utf-8', wantsComments: true })
+      assert.equal(after.NSCameraUsageDescription.text, '새카메라')
+      assert.equal(after.NSMicrophoneUsageDescription.text, '기존마이크')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('removes a PR-N InfoPlist entry from base when its translation is empty', async () => {
+    const dir = await makeTempDir('compile-ios-merge-')
+    try {
+      const srcDir = path.join(dir, 'src')
+      const transDir = path.join(dir, 'trans')
+      const lprojDir = path.join(srcDir, 'ko.lproj')
+      await fsp.mkdir(lprojDir, { recursive: true })
+      await fsp.mkdir(transDir)
+      const stringsPath = path.join(lprojDir, 'InfoPlist.strings')
+
+      await fsp.writeFile(stringsPath,
+        '\n"NSCameraUsageDescription" = "기존카메라";\n' +
+        '\n"NSMicrophoneUsageDescription" = "기존마이크";\n',
+        { encoding: 'utf-8' },
+      )
+
+      await writeTransFiles(transDir, {
+        ko: [{ context: 'NSCameraUsageDescription', key: 'Camera', messages: {}, flag: null }],
+      })
+
+      await compileToIosStrings('d', makeIosConfig(srcDir), transDir, {
+        mergeKeys: new Set(['Camera']),
+      })
+
+      const after = i18nStringsFiles.readFileSync(stringsPath, { encoding: 'utf-8', wantsComments: true })
+      assert.equal(after.NSCameraUsageDescription, undefined)
+      assert.equal(after.NSMicrophoneUsageDescription.text, '기존마이크')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not touch the InfoPlist when mergeKeys is empty', async () => {
+    const dir = await makeTempDir('compile-ios-merge-')
+    try {
+      const srcDir = path.join(dir, 'src')
+      const transDir = path.join(dir, 'trans')
+      const lprojDir = path.join(srcDir, 'ko.lproj')
+      await fsp.mkdir(lprojDir, { recursive: true })
+      await fsp.mkdir(transDir)
+      const stringsPath = path.join(lprojDir, 'InfoPlist.strings')
+
+      const original = '\n"NSCameraUsageDescription" = "기존카메라";\n'
+      await fsp.writeFile(stringsPath, original, { encoding: 'utf-8' })
+
+      await writeTransFiles(transDir, { ko: [] })
+
+      await compileToIosStrings('d', makeIosConfig(srcDir), transDir, {
+        mergeKeys: new Set(),
+      })
+
+      const after = await fsp.readFile(stringsPath, { encoding: 'utf-8' })
+      assert.equal(after, original)
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes only PR-N keys when the InfoPlist file does not exist yet', async () => {
+    const dir = await makeTempDir('compile-ios-merge-')
+    try {
+      const srcDir = path.join(dir, 'src')
+      const transDir = path.join(dir, 'trans')
+      const lprojDir = path.join(srcDir, 'ko.lproj')
+      await fsp.mkdir(lprojDir, { recursive: true })
+      await fsp.mkdir(transDir)
+      const stringsPath = path.join(lprojDir, 'InfoPlist.strings')
+      await fsp.writeFile(stringsPath, '', { encoding: 'utf-8' })
+
+      await writeTransFiles(transDir, {
+        ko: [{ context: 'NSCameraUsageDescription', key: 'Camera', messages: { other: '새카메라' }, flag: null }],
+      })
+
+      await compileToIosStrings('d', makeIosConfig(srcDir), transDir, {
+        mergeKeys: new Set(['Camera']),
+      })
+
+      const after = i18nStringsFiles.readFileSync(stringsPath, { encoding: 'utf-8', wantsComments: true })
+      assert.equal(after.NSCameraUsageDescription.text, '새카메라')
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/plugin-ios/src/compiler.ts
+++ b/packages/plugin-ios/src/compiler.ts
@@ -7,14 +7,17 @@ import PQueue from 'p-queue'
 import os from 'os'
 import plist from 'plist'
 import {
+  type CompileOptions,
   type CompilerConfig,
   EntryCollection,
   execWithLog,
   extractLocaleFromTransPath,
   fileExists,
   getTempDir,
+  isErrnoException,
   listTransPaths,
   readTransEntries,
+  type TransEntry,
   type TransMessages,
 } from 'l10n-tools-core'
 
@@ -34,7 +37,19 @@ type StringsDictValue = {
   } & TransMessages,
 }
 
-export async function compileToIosStrings(domainName: string, config: CompilerConfig, transDir: string) {
+type StringsDict = { [key: string]: StringsDictValue }
+
+export async function compileToIosStrings(
+  domainName: string,
+  config: CompilerConfig,
+  transDir: string,
+  options?: CompileOptions,
+) {
+  const mergeKeys = options?.mergeKeys
+  if (mergeKeys != null && mergeKeys.size === 0) {
+    return
+  }
+
   const tempDir = path.join(getTempDir(), 'compiler')
   await fsp.mkdir(tempDir, { recursive: true })
   const srcDir = config.getSrcDir()
@@ -45,21 +60,30 @@ export async function compileToIosStrings(domainName: string, config: CompilerCo
   for (const transPath of transPaths) {
     const locale = extractLocaleFromTransPath(transPath)
 
-    const trans = EntryCollection.loadEntries(await readTransEntries(transPath))
+    const transEntries = await readTransEntries(transPath)
+    const trans = EntryCollection.loadEntries(transEntries)
 
     const queue = new PQueue({ concurrency: os.cpus().length })
     async function compile(stringsPath: string) {
       log.info('compile', stringsPath)
       const stringsName = path.basename(stringsPath, '.strings')
       if (stringsName === 'InfoPlist') {
-        const strings: CommentedI18nStringsMsg = {}
+        const strings: CommentedI18nStringsMsg = mergeKeys != null
+          ? await readStringsIfExists(stringsPath)
+          : {}
         for (const key of infoPlistKeys) {
+          if (!shouldProcessKey(key, transEntries, mergeKeys)) {
+            continue
+          }
           const transEntry = trans.find(key, null)
           if (transEntry && transEntry.messages.other) {
             strings[key] = {
               text: transEntry.messages.other || transEntry.key,
             }
-          } else {
+          } else if (mergeKeys == null) {
+            delete strings[key]
+          } else if (transEntry != null) {
+            // PR-N key with no usable translation: drop from output.
             delete strings[key]
           }
         }
@@ -68,13 +92,24 @@ export async function compileToIosStrings(domainName: string, config: CompilerCo
         await fsp.writeFile(stringsPath, output, { encoding: 'utf-8' })
       } else if (stringsName === 'Localizable') {
         await execWithLog(`find "${srcDir}" -name "*.swift" -print0 | xargs -0 genstrings -q -u -SwiftUI -o "${tempDir}"`)
-        const strings = i18nStringsFiles.readFileSync(path.join(tempDir, 'Localizable.strings'), { encoding: 'utf16le', wantsComments: true })
-        const stringsDict: { [key: string]: StringsDictValue } = {}
+        const srcStrings = i18nStringsFiles.readFileSync(path.join(tempDir, 'Localizable.strings'), { encoding: 'utf16le', wantsComments: true })
         const stringsDictPath = path.join(path.dirname(stringsPath), stringsName + '.stringsdict')
-        for (const key of Object.keys(strings)) {
+
+        const strings: CommentedI18nStringsMsg = mergeKeys != null
+          ? await readStringsIfExists(stringsPath)
+          : srcStrings
+        const stringsDict: StringsDict = mergeKeys != null
+          ? await readStringsDictIfExists(stringsDictPath)
+          : {}
+
+        for (const key of Object.keys(srcStrings)) {
+          if (!shouldProcessKey(key, transEntries, mergeKeys)) {
+            continue
+          }
           const transEntry = trans.find(null, key)
           if (transEntry && transEntry.messages['other']) {
-            strings[key].text = transEntry.messages['other']
+            const baseEntry = strings[key] ?? srcStrings[key]
+            strings[key] = { ...baseEntry, text: transEntry.messages['other'] }
             if (Object.keys(transEntry.messages).length > 1) {
               if (!await fileExists(stringsDictPath)) {
                 throw new Error(`[${locale}] Add ${stringsName}.stringsdict file to project to utilize plural translation`)
@@ -88,9 +123,15 @@ export async function compileToIosStrings(domainName: string, config: CompilerCo
                   ...messages,
                 },
               }
+            } else {
+              delete stringsDict[key]
             }
-          } else {
+          } else if (mergeKeys == null) {
             delete strings[key]
+            delete stringsDict[key]
+          } else if (transEntry != null) {
+            delete strings[key]
+            delete stringsDict[key]
           }
         }
 
@@ -106,12 +147,23 @@ export async function compileToIosStrings(domainName: string, config: CompilerCo
           if (await fileExists(xibPath)) {
             const tempStringsPath = path.join(tempDir, stringsName + '.strings')
             await execWithLog(`ibtool --export-strings-file "${tempStringsPath}" "${xibPath}"`)
-            const strings = i18nStringsFiles.readFileSync(tempStringsPath, { encoding: 'utf16le', wantsComments: true })
-            for (const key of Object.keys(strings)) {
+            const srcStrings = i18nStringsFiles.readFileSync(tempStringsPath, { encoding: 'utf16le', wantsComments: true })
+
+            const strings: CommentedI18nStringsMsg = mergeKeys != null
+              ? await readStringsIfExists(stringsPath)
+              : srcStrings
+
+            for (const key of Object.keys(srcStrings)) {
+              if (!shouldProcessKey(key, transEntries, mergeKeys)) {
+                continue
+              }
               const transEntry = trans.find(key, null)
               if (transEntry && transEntry.messages.other) {
-                strings[key].text = transEntry.messages.other || transEntry.key
-              } else {
+                const baseEntry = strings[key] ?? srcStrings[key]
+                strings[key] = { ...baseEntry, text: transEntry.messages.other || transEntry.key }
+              } else if (mergeKeys == null) {
+                delete strings[key]
+              } else if (transEntry != null) {
                 delete strings[key]
               }
             }
@@ -127,6 +179,63 @@ export async function compileToIosStrings(domainName: string, config: CompilerCo
     await queue.addAll(stringsPaths.map(stringsPath => () => compile(stringsPath)))
   }
   await fsp.rm(tempDir, { force: true, recursive: true })
+}
+
+/**
+ * Whether the given strings-file `key` is in scope for processing under the current mode.
+ *
+ * - In full-rewrite mode (mergeKeys is null), every src-discovered key is processed.
+ * - In merge mode, only keys that correspond to a PR-N trans entry are touched. We
+ *   treat "key matches a trans entry by entry.context or by entry.key (when context-less)"
+ *   as in-scope, so non-PR keys remain untouched in the existing output.
+ *
+ * @internal exported for testing
+ */
+export function shouldProcessKey(
+  key: string,
+  transEntries: TransEntry[],
+  mergeKeys: Set<string> | undefined,
+): boolean {
+  if (mergeKeys == null) {
+    return true
+  }
+  return transEntries.some(entry => entry.context === key || (entry.context == null && entry.key === key))
+}
+
+async function readStringsIfExists(stringsPath: string): Promise<CommentedI18nStringsMsg> {
+  try {
+    return i18nStringsFiles.readFileSync(stringsPath, { encoding: 'utf-8', wantsComments: true })
+  } catch (err) {
+    if (isErrnoException(err, 'ENOENT')) {
+      return {}
+    }
+    // i18n-strings-files may also surface utf-8 → utf-16 mismatch as a parse error;
+    // fall back to utf-16 read in that case.
+    try {
+      return i18nStringsFiles.readFileSync(stringsPath, { encoding: 'utf16le', wantsComments: true })
+    } catch (err2) {
+      if (isErrnoException(err2, 'ENOENT')) {
+        return {}
+      }
+      throw err2
+    }
+  }
+}
+
+async function readStringsDictIfExists(stringsDictPath: string): Promise<StringsDict> {
+  try {
+    const text = await fsp.readFile(stringsDictPath, { encoding: 'utf-8' })
+    const parsed = plist.parse(text) as unknown
+    if (parsed != null && typeof parsed === 'object') {
+      return parsed as StringsDict
+    }
+    return {}
+  } catch (err) {
+    if (isErrnoException(err, 'ENOENT')) {
+      return {}
+    }
+    throw err
+  }
 }
 
 async function getStringsPaths(srcDir: string, locale: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

`_compile --source PR-N`이 PR scope 키만 담은 새 출력 파일을 만들지 않고, 기존 출력 파일을 베이스로 PR-N 키 영역만 update 하도록 동작을 변경합니다. workflow-storage `sync-pr-l10n` action의 git-diff 검증이 PR scope 변경분만 정확히 검출하도록 만들기 위함입니다.

- core: `CompilerFunc`에 optional `CompileOptions.mergeKeys?: Set<string>` 인자 추가 (backward-compatible)
- compiler-json / compiler-gettext / plugin-android / plugin-ios: 각 컴파일러가 mergeKeys를 받아 기존 출력에서 해당 키만 update, 나머지는 보존
- cli: `_compile --source PR-N`이 snapshots의 keyName Set을 mergeKeys로 전달

PR-N 키가 0개인 도메인은 출력 파일을 건드리지 않습니다. 기존 출력이 없을 때는 PR-N 키만 작성합니다.

## Test plan

- [x] core / compiler-json / compiler-gettext / plugin-android / plugin-ios 단위 테스트 추가 — 모든 패키지 통과
- [x] `npm run build` / `npm run lint` 통과
- [ ] likey-backend PR #7419 (시나리오 5, 6) — 패키지 릴리스 후 검증
- [ ] likey-backend PR #7420 (시나리오 3 — 의도된 한계 재확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)