### PR TITLE
ci: bump checkout/setup-node to v6 and cache to v5

### DIFF
--- a/.github/actions/setup-node-cached/action.yml
+++ b/.github/actions/setup-node-cached/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
@@ -31,7 +31,7 @@ runs:
 
     - name: Cache node_modules
       id: node-modules-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.path }}/node_modules
         key: "${{ runner.os }}-node-modules-${{ hashFiles('.package-lock-for-cache.json') }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.syncer_l10n_storage }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -47,7 +47,7 @@ jobs:
       BACKEND_IMAGE: ${{ secrets.BACKEND_IMAGE }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,7 @@ jobs:
         path: ${{ fromJson(needs.release-please.outputs.paths_released) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup node with cached node_modules
         uses: ./.github/actions/setup-node-cached

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         version: [22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup node with cached node_modules
         uses: ./.github/actions/setup-node-cached
         with:


### PR DESCRIPTION
## Summary
- Node 20 기반 actions deprecation 대응을 위해 `actions/checkout` v4→v6, `actions/setup-node` v4→v6, `actions/cache` v4→v5 로 업그레이드
- 각 action의 최신 stable major 버전이 달라 개별 확인 후 적용 (cache는 아직 v5가 최신)

## Breaking change 검토
- **checkout v5/v6**: Node 24 런타임 (runner v2.327.1+ 필요) — `ubuntu-latest`라 영향 없음
- **setup-node v5**: `package.json`에 `packageManager` 필드가 있을 때 자동 npm 캐싱 활성화 → 본 리포 `package.json`에 해당 필드 없음, composite action의 `actions/cache`(node_modules 직접 캐싱)와 충돌 없음
- **setup-node v6**: 자동 캐싱이 npm으로 한정 — 자동 캐싱 미사용이라 영향 없음
- **cache v5**: Node 24 런타임 변경만, 다른 breaking 없음

## Test plan
- [ ] PR에서 `Test` 워크플로우(node 22, 24 매트릭스) 통과 확인
- [ ] PR에서 `E2E Tests` 워크플로우 통과 확인
- [ ] 머지 후 `release-please` 워크플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)