### PR TITLE
fix(syncer-l10n-storage): match server keys by local source text on download

### DIFF
--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { KeyEntry, TransEntry } from 'l10n-tools-core'
 import type { L10nKeyToServe } from './api-types.js'
-import { buildKeyChanges } from './l10n-storage.js'
+import { buildKeyChanges, updateTransEntries } from './l10n-storage.js'
 
 function createKeyEntry(key: string, opts?: { isPlural?: boolean, context?: string | null }): KeyEntry {
   return {
@@ -226,5 +226,186 @@ describe('buildKeyChanges', () => {
     )
 
     assert.equal(updatingKeys.length, 0)
+  })
+})
+
+describe('updateTransEntries', () => {
+  it('matches server keys via local keyEntry source text and applies translation', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [createTransEntry('공개 범위', { other: 'old en value' }, { context: 'post_editor_access_config_title' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].messages.other, 'Media Access')
+  })
+
+  it('uses local source text to disambiguate when same named key is registered under multiple keyName entries', () => {
+    // Same named key 'setting_paid_post_config_config_label' is in context of two keyName entries.
+    // values/strings.xml has '유료 포스트 앱에서만 열람 설정' as the source,
+    // so the matching keyName must be the one identical to the local source.
+    const keyEntries = [
+      createKeyEntry('유료 포스트 앱에서만 열람 설정', { context: 'setting_paid_post_config_config_label' }),
+    ]
+    const listedKeyMap = {
+      '유료 포스트 앱에서만 열람 설정': createL10nKey('유료 포스트 앱에서만 열람 설정', {
+        translations: [
+          { locale: 'en', translation: { other: 'Set my paid post to app-only view' } },
+        ],
+      }),
+      '내 유료 포스트 앱에서만 열람 설정': createL10nKey('내 유료 포스트 앱에서만 열람 설정', {
+        translations: [
+          { locale: 'en', translation: { other: 'WRONG (should not be picked)' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [createTransEntry('유료 포스트 앱에서만 열람 설정', { other: 'old' }, { context: 'setting_paid_post_config_config_label' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].messages.other, 'Set my paid post to app-only view')
+  })
+
+  it('does not touch translation lines whose local key has no matching server keyName', () => {
+    const keyEntries = [createKeyEntry('orphan key', { context: 'orphan_named_key' })]
+    const listedKeyMap = {}
+    const allTransEntries = {
+      en: [createTransEntry('orphan key', { other: 'keep me' }, { context: 'orphan_named_key', flag: 'unverified' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].messages.other, 'keep me')
+    // flag is only cleared when a matching server key updates the entry; here it must remain.
+    assert.equal(allTransEntries.en[0].flag, 'unverified')
+  })
+
+  it('applies localeSyncMap when looking up server translation locale', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'zh-CN', translation: { other: '公开范围' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      'zh-rCN': [createTransEntry('공개 범위', { other: 'old zh-rCN' }, { context: 'post_editor_access_config_title' })],
+    }
+    const localeSyncMap = { 'zh-rCN': 'zh-CN' }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap, localeSyncMap)
+
+    assert.equal(allTransEntries['zh-rCN'][0].messages.other, '公开范围')
+  })
+
+  it('skips when server key has no translation for the requested locale', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      ja: [createTransEntry('공개 범위', { other: '既存ja' }, { context: 'post_editor_access_config_title' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.ja[0].messages.other, '既存ja')
+  })
+
+  it('clears flag on entries that get updated by a matching server key', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [createTransEntry('공개 범위', { other: 'old' }, { context: 'post_editor_access_config_title', flag: 'unverified' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].flag, null)
+  })
+
+  it('applies the same server keyName to multiple local entries that share the source text', () => {
+    // server-side normal case: one keyName has many context-named keys mapped to the same source text.
+    const keyEntries = [
+      createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' }),
+      createKeyEntry('공개 범위', { context: 'post_tab_filter_visibility_label' }),
+    ]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [
+        createTransEntry('공개 범위', { other: 'old1' }, { context: 'post_editor_access_config_title' }),
+        createTransEntry('공개 범위', { other: 'old2' }, { context: 'post_tab_filter_visibility_label' }),
+      ],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].messages.other, 'Media Access')
+    assert.equal(allTransEntries.en[1].messages.other, 'Media Access')
+  })
+
+  it('updates plural translations when not equal', () => {
+    const keyEntries = [createKeyEntry('plural source', { isPlural: true, context: 'plural_ctx' })]
+    const listedKeyMap = {
+      'plural source': createL10nKey('plural source', {
+        isPlural: true,
+        translations: [
+          { locale: 'en', translation: { one: 'one item', other: '%d items' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [createTransEntry('plural source', { one: 'old one', other: 'old other' }, { context: 'plural_ctx' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.deepEqual(allTransEntries.en[0].messages, { one: 'one item', other: '%d items' })
+  })
+
+  it('does not overwrite when server value equals current value', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const original = createTransEntry('공개 범위', { other: 'Media Access' }, { context: 'post_editor_access_config_title' })
+    const allTransEntries = { en: [original] }
+    const beforeMessages = original.messages
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    // identity check: the messages object should not be replaced when equal
+    assert.equal(allTransEntries.en[0].messages, beforeMessages)
   })
 })

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -390,6 +390,24 @@ describe('updateTransEntries', () => {
     assert.deepEqual(allTransEntries.en[0].messages, { one: 'one item', other: '%d items' })
   })
 
+  it('clears flag even when server value equals current value', () => {
+    const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
+    const listedKeyMap = {
+      '공개 범위': createL10nKey('공개 범위', {
+        translations: [
+          { locale: 'en', translation: { other: 'Media Access' } },
+        ],
+      }),
+    }
+    const allTransEntries = {
+      en: [createTransEntry('공개 범위', { other: 'Media Access' }, { context: 'post_editor_access_config_title', flag: 'unverified' })],
+    }
+
+    updateTransEntries(keyEntries, allTransEntries, listedKeyMap)
+
+    assert.equal(allTransEntries.en[0].flag, null)
+  })
+
   it('does not overwrite when server value equals current value', () => {
     const keyEntries = [createKeyEntry('공개 범위', { context: 'post_editor_access_config_title' })]
     const listedKeyMap = {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -8,7 +8,7 @@ import {
   type TransEntry,
   type TransMessages,
 } from 'l10n-tools-core'
-import { chunk, invert, isEqual } from 'es-toolkit/compat'
+import { chunk, isEqual } from 'es-toolkit/compat'
 import { L10nStorageApiClient } from './api-client.js'
 import type {
   CreateL10nKeyInput,
@@ -64,7 +64,6 @@ export async function syncTransToL10nStorage(
 
   const localeSyncMap = storageConfig.getLocaleSyncMap()
   if (localeSyncMap) assertBijectiveLocaleSyncMap(localeSyncMap)
-  const invertedSyncMap = localeSyncMap ? invert(localeSyncMap) : undefined
 
   const apiClient = new L10nStorageApiClient(url, token)
 
@@ -81,7 +80,7 @@ export async function syncTransToL10nStorage(
   )
 
   // 3. 서버 번역을 로컬에 반영
-  updateTransEntries(tag, allTransData, listedKeyMap, invertedSyncMap)
+  updateTransEntries(keyEntries, allTransData, listedKeyMap, localeSyncMap)
 
   // 4. l10n-storage에 업로드
   await uploadToL10nStorage(apiClient, projectId, creatingKeys, updatingKeys, skipUpload)
@@ -319,43 +318,48 @@ export function buildKeyChanges(
 
 // --- Download translations to local ---
 
-function updateTransEntries(
-  tag: string,
+/** @internal exported for testing */
+export function updateTransEntries(
+  keyEntries: KeyEntry[],
   allTransEntries: { [locale: string]: TransEntry[] },
   listedKeyMap: { [keyName: string]: L10nKeyToServe },
-  invertedSyncMap?: { [locale: string]: string },
+  localeSyncMap?: { [locale: string]: string },
 ) {
-  // keys-to-serve가 locale별 정책(serveSuggestions)을 이미 적용해 단일 translations로 내려주므로
-  // 클라이언트는 그대로 반영하기만 하면 된다. unverified flag는 더 이상 사용하지 않는다.
-  for (const [keyName, key] of Object.entries(listedKeyMap)) {
-    for (const tr of key.translations) {
-      const locale = invertedSyncMap?.[tr.locale] ?? tr.locale
-      if (allTransEntries[locale] == null) continue
+  // 로컬 keyEntries(소스의 한국어 원문 기준)를 순회하며, 같은 한국어 keyName을 가진 서버 키의
+  // 번역을 strings.xml(values-{locale}) 라인에 적용한다. 서버 데이터에 같은 named key가 여러
+  // keyName 항목 context에 동시에 등록된 부정합이 있어도, 로컬 소스의 한국어 원문이 매칭을
+  // 결정하므로 결과가 안정적이다. keys-to-serve는 이미 locale별 정책이 적용된 단일 translations만
+  // 내려주므로 클라이언트는 그대로 반영하기만 하면 된다. unverified flag는 더 이상 사용하지 않는다.
+  for (const [locale, transEntries] of Object.entries(allTransEntries)) {
+    const serverLocale = localeSyncMap?.[locale] ?? locale
+    const trans = EntryCollection.loadEntries(transEntries)
 
-      const trans = EntryCollection.loadEntries(allTransEntries[locale])
-      const contexts = [...getContextsFromMetadata(key.metadata, tag), null]
+    for (const keyEntry of keyEntries) {
+      const listedKey = listedKeyMap[keyEntry.key]
+      if (listedKey == null) continue
 
-      for (const keyContext of contexts) {
-        const transEntry = trans.find(keyContext, keyName)
-        if (!transEntry) continue
+      const tr = listedKey.translations.find(t => t.locale === serverLocale)
+      if (tr == null) continue
 
-        transEntry.flag = null
+      const transEntry = trans.find(keyEntry.context, keyEntry.key)
+      if (transEntry == null) continue
 
-        if (key.isPlural) {
-          const translations: Record<string, string> = {}
-          for (const [form, value] of Object.entries(tr.translation)) {
-            if (value) translations[form] = value
-          }
-          if (Object.keys(translations).length > 0 && !isEqual(transEntry.messages, translations)) {
-            log.verbose('updateTransEntries', `updating ${locale} value of ${keyName}`)
-            transEntry.messages = translations as TransMessages
-          }
-        } else {
-          const value = tr.translation.other
-          if (value && value !== transEntry.messages.other) {
-            log.verbose('updateTransEntries', `updating ${locale} value of ${keyName}`)
-            transEntry.messages = { other: value }
-          }
+      transEntry.flag = null
+
+      if (listedKey.isPlural) {
+        const translations: Record<string, string> = {}
+        for (const [form, value] of Object.entries(tr.translation)) {
+          if (value) translations[form] = value
+        }
+        if (Object.keys(translations).length > 0 && !isEqual(transEntry.messages, translations)) {
+          log.verbose('updateTransEntries', `updating ${locale} value of ${keyEntry.key}`)
+          transEntry.messages = translations as TransMessages
+        }
+      } else {
+        const value = tr.translation.other
+        if (value && value !== transEntry.messages.other) {
+          log.verbose('updateTransEntries', `updating ${locale} value of ${keyEntry.key}`)
+          transEntry.messages = { other: value }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix the l10n-storage download path so the local source text decides which server key supplies the translation, instead of iterating server keys and overwriting strings.xml lines based on `metadata.context`.
- This eliminates a class of unstable diffs where the same named key was registered in the `context` of multiple keyName entries on the server, causing the result to depend on traversal order.
- Adds unit tests for the disambiguation behavior, `localeSyncMap` application, plural updates, and no-op cases.

## Background
While migrating likey-android from lokalise to l10n-storage, several `strings.xml` lines flipped to translations that did not match the source text in `values/strings.xml`. Investigation showed that on the server the same Android named key (e.g. `setting_paid_post_config_config_label`) was registered under two distinct keyName entries (e.g. "유료 포스트…" and "내 유료 포스트…"). The previous matching model walked server keys and let each key's context-named entries overwrite local translations, so the last one processed won.

The new model walks local `keyEntries` and looks up server keys by `keyName === keyEntry.key`, which is the source text in `values/strings.xml`. Duplicate context registrations on the server no longer affect the outcome.

## Test plan
- [x] `npm test` (added 9 unit tests; all 26 tests in this package pass)
- [x] `npm run build` & `npm run lint`
- [x] End-to-end check on likey-android worktree: 5 of 6 originally-changed keys revert to no-op, and the only remaining change (`live_cast_mem_config_dialog_title`) is the intended one — its `values/strings.xml` source text legitimately points to the new keyName.

🤖 Generated with [Claude Code](https://claude.com/claude-code)