### PR TITLE
feat(cli): add _remoteCount internal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,51 @@ Options:
   -t, --tags <tags>                  Additional tags for keys (comma separated)
 ```
 
+## Internal commands
+
+These commands are prefixed with `_` and are intended for scripting / automation, not day-to-day use. Their flags and output are kept stable but their purpose is to be composed by other tooling.
+
+### `_remoteCount` — Count translations on the sync target
+
+Query the sync target directly and report translation counts per locale, without downloading translations into the local cache. Useful for verifying upload completeness or driving dashboards.
+
+```bash
+# Sum across all domains (locale union)
+l10n _remoteCount --source web
+
+# Specific domain
+l10n -d web _remoteCount --source web
+
+# Multiple domains → one line per domain
+l10n -d web,mobile _remoteCount --source web
+
+# Filter by spec
+l10n _remoteCount --source web -s untranslated
+l10n _remoteCount --source web -s translated,untranslated
+
+# Specific locales
+l10n _remoteCount --source web -l en,ko
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--source <source>` | Source identifier to filter by. Omit to count all keys for the domain's tag. |
+| `-l, --locales <locales>` | Comma-separated locales (default: each domain's configured locales). |
+| `-s, --spec <spec>` | Comma-separated specs, `!` prefix to negate. Supported: `total` (default), `translated`, `untranslated`. |
+
+Output format:
+
+- One line per domain: `<domain>,<locale>:<count>,<locale>:<count>,...`
+- When `-d/--domains` is omitted, a single aggregate line is emitted with `*` as the domain name. Locales are the union of each domain's locales (insertion order); a locale's count is the sum across the domains that include it.
+
+Notes:
+
+- Requires a sync target that supports source listing (currently `l10n-storage`).
+- Counts are by `(context, key)` pair, matching `_count` semantics — a key with multiple contexts is counted per context.
+- The l10n-storage backend has no `unverified` flag, so `unverified` / `!unverified` specs always behave as if all entries are verified.
+
 ## Requirements
 
 - Node.js >= 22.19.0

--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -392,6 +392,14 @@ async function run() {
     .option('-s, --spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated')
     .option('--source <source>', 'source identifier to filter (l10n-storage); omit to count all keys for the tag')
     .action(async (opts: RemoteCountOptions, cmd: Command) => {
+      const supportedSpecs = new Set(['total', 'translated', 'untranslated'])
+      const specs = opts['spec'] ? opts['spec'].split(',') : ['total']
+      const invalidSpecs = specs.filter(s => !supportedSpecs.has(s.startsWith('!') ? s.slice(1) : s))
+      if (invalidSpecs.length > 0) {
+        log.error(cmd.name(), `unsupported spec(s): ${invalidSpecs.join(',')}; supported: ${[...supportedSpecs].join(', ')}`)
+        process.exit(1)
+      }
+
       const isAggregate = !program.opts<ProgramOptions>()['domains']
       const aggregate = new Map<string, number>()
 
@@ -405,7 +413,6 @@ async function run() {
 
         const tag = domainConfig.getTag()
         const locales: string[] = opts['locales'] ? opts['locales'].split(',') : domainConfig.getLocales()
-        const specs = opts['spec'] ? opts['spec'].split(',') : ['total']
 
         const snapshots = await sourceFilter(config, domainConfig, tag, opts.source)
 

--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -20,6 +20,7 @@ import {
   type SyncerKeySnapshot,
   type SyncerOptions,
   syncTransToTarget,
+  type TransEntry,
   updateTrans,
 } from 'l10n-tools-core'
 import * as path from 'path'
@@ -378,6 +379,69 @@ async function run() {
         }
         process.stdout.write(`${domainName},${counts.join(',')}\n`)
       })
+    })
+
+  type RemoteCountOptions = {
+    locales?: string,
+    spec?: string,
+    source?: string,
+  }
+  program.command('_remoteCount')
+    .description('Count remote translations from sync target (internal use only)')
+    .option('-l, --locales [locales]', 'locales to count (comma separated)')
+    .option('-s, --spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated')
+    .option('--source <source>', 'source identifier to filter (l10n-storage); omit to count all keys for the tag')
+    .action(async (opts: RemoteCountOptions, cmd: Command) => {
+      const isAggregate = !program.opts<ProgramOptions>()['domains']
+      const aggregate = new Map<string, number>()
+
+      await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
+        const syncTarget = config.getSyncTarget()
+        const sourceFilter = pluginRegistry.getSourceFilter(syncTarget)
+        if (!sourceFilter) {
+          log.error(cmd.name(), `sync target '${syncTarget}' does not support remote listing`)
+          process.exit(1)
+        }
+
+        const tag = domainConfig.getTag()
+        const locales: string[] = opts['locales'] ? opts['locales'].split(',') : domainConfig.getLocales()
+        const specs = opts['spec'] ? opts['spec'].split(',') : ['total']
+
+        const snapshots = await sourceFilter(config, domainConfig, tag, opts.source)
+
+        const counts: string[] = []
+        for (const locale of locales) {
+          const useUnverified = config.useUnverified(locale)
+          let count = 0
+          for (const snapshot of snapshots) {
+            const messages = snapshot.translations[locale] ?? {}
+            for (const context of snapshot.contexts) {
+              const transEntry: TransEntry = {
+                context,
+                key: snapshot.keyName,
+                messages,
+                flag: null,
+              }
+              if (checkTransEntrySpecs(transEntry, specs, useUnverified)) {
+                count++
+              }
+            }
+          }
+          if (isAggregate) {
+            aggregate.set(locale, (aggregate.get(locale) ?? 0) + count)
+          } else {
+            counts.push(locale + ':' + count)
+          }
+        }
+        if (!isAggregate) {
+          process.stdout.write(`${domainName},${counts.join(',')}\n`)
+        }
+      })
+
+      if (isAggregate) {
+        const counts = [...aggregate.entries()].map(([l, c]) => `${l}:${c}`)
+        process.stdout.write(`*,${counts.join(',')}\n`)
+      }
     })
 
   type CatOptions = {


### PR DESCRIPTION
## Summary
- Adds `l10n _remoteCount` internal command that queries the sync target directly and reports translation counts per locale, without downloading translations into the local cache.
- Supports `--source` filter (l10n-storage), `-l/--locales`, and `-s/--spec` (`total`/`translated`/`untranslated`, comma-separated, `!`-prefix to negate).
- When `-d/--domains` is omitted, emits a single aggregate line with `*` as the domain name and the locale union summed across domains.
- Documents the new command under a new "Internal commands" section in README.md.

## Test plan
- [ ] `l10n _remoteCount --source <s>` (no `-d`) prints `*,<locale>:<count>,...` aggregate line
- [ ] `l10n -d <domain> _remoteCount --source <s>` prints `<domain>,<locale>:<count>,...`
- [ ] `l10n -d a,b _remoteCount --source <s>` prints two lines, one per domain
- [ ] `-s untranslated` / `-s translated` filter the count correctly
- [ ] `-l en,ko` overrides domain locales
- [ ] Sync target without source filter (e.g. lokalise) errors out gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)