### PR TITLE
ci: PR draft → ready 전환 시 중복 실행되던 test/e2e 제거

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize]
 
 jobs:
   changes:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- `pull_request.types`에서 `ready_for_review` 제거 (`test.yml`, `e2e.yml`)
- draft 상태에서도 모든 잡이 실행되고 있어 ready 전환 시점의 재실행은 동일 커밋에 대한 순수 중복이었음
- test/e2e 워크플로우 러너 시간 절감

## Test plan
- [ ] PR이 draft로 열린 직후 test/e2e가 정상 실행되는지 확인
- [ ] draft → ready 전환 시 test/e2e가 재실행되지 않는지 확인
- [ ] commit push 시 test/e2e가 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)