### PR TITLE
fix(cli): drop conflicting -s short alias from internal _count/_remoteCount/_cat --spec

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -357,7 +357,7 @@ async function run() {
     .description('Count translations (internal use only)')
     .option('--trans-dir [transDir]', 'directory to load translation files')
     .option('-l, --locales [locales]', 'locales to count (comma separated)')
-    .option('-s, --spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated,<flag>')
+    .option('--spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated,<flag>')
     .action(async (opts: CountOptions, cmd: Command) => {
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
         const cacheDir = domainConfig.getCacheDir()
@@ -389,7 +389,7 @@ async function run() {
   program.command('_remoteCount')
     .description('Count remote translations from sync target (internal use only)')
     .option('-l, --locales [locales]', 'locales to count (comma separated)')
-    .option('-s, --spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated')
+    .option('--spec [spec]', 'spec to count (required, negate if starting with !, comma separated) supported: total,translated,untranslated')
     .option('--source <source>', 'source identifier to filter (l10n-storage); omit to count all keys for the tag')
     .action(async (opts: RemoteCountOptions, cmd: Command) => {
       const supportedSpecs = new Set(['total', 'translated', 'untranslated'])
@@ -460,7 +460,7 @@ async function run() {
     .description('Print translation entries (internal use only)')
     .option('--trans-dir [transDir]', 'directory to read translations')
     .option('-l, --locale [locale]', 'locale to print (required)')
-    .option('-s, --spec [spec]', 'spec to print (required, negate if starting with !, comma separated) supported: total,translated,untranslated,<flag>')
+    .option('--spec [spec]', 'spec to print (required, negate if starting with !, comma separated) supported: total,translated,untranslated,<flag>')
     .action(async (opts: CatOptions, cmd: Command) => {
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
         if (!opts['locale']) {


### PR DESCRIPTION
## Summary
- program-level `-s, --skip-validation` (boolean)이 internal 서브커맨드(`_count`, `_remoteCount`, `_cat`)의 `-s, --spec [spec]`를 가려서, `l10n _remoteCount --source PR-123 -s total` 같은 호출이 `error: too many arguments` 로 실패하던 문제 수정
- 세 internal 커맨드의 `--spec` 옵션에서 short alias `-s`만 제거. long form `--spec`은 그대로 동작

## 배경
- `_count`/`_cat`의 `-s, --spec`은 2025-12-29 (커밋 e6a98246)부터 존재하던 잠재 버그
- `_remoteCount`는 PR #326에서 같은 패턴으로 추가되어 충돌이 표면화됨
- internal 커맨드는 `_` prefix로 호출처가 적고 short alias 우선순위가 낮으므로, user-facing인 program-level `-s, --skip-validation`을 유지하고 internal 쪽 short alias를 제거하는 방향이 risk 최소

## 재현
```sh
npx l10n _remoteCount --source "PR-123" -s total
# error: too many arguments for '_remoteCount'. Expected 0 arguments but got 1.
```
`-s`가 program-level boolean으로 먼저 파싱되어 뒤의 `total`이 positional로 남아 발생.

## Test plan
- [x] `npm run build` 통과
- [x] `npm test` 통과 (10 pass / 0 fail)
- [x] `npm run lint` 통과
- [x] `node packages/cli/dist/l10n.js _count --help`, `_remoteCount --help`, `_cat --help`에서 `--spec`이 short alias 없이 노출되는지 확인
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)