### PR TITLE
fix(cli): use snapshot-based merge for `sync --source` compile

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -66,6 +66,28 @@ async function fetchSourceSnapshots(
 }
 
 /**
+ * Compile a source-scoped subset of keys into the existing target file(s) by merging
+ * the snapshot output on top of the current output. Used by both `sync --source` and
+ * `_compile --source` so the merge semantics stay identical between the two paths.
+ */
+async function compileFromSource(
+  cmdName: string,
+  config: L10nConfig,
+  domainConfig: DomainConfig,
+  domainName: string,
+  source: string,
+): Promise<void> {
+  const snapshots = await fetchSourceSnapshots(cmdName, config, domainConfig, source)
+  const mergeKeys = new Set(snapshots.map(s => s.keyName))
+  const tempDir = await materializeSnapshotsToTempDir(domainName, snapshots, domainConfig.getLocales())
+  try {
+    await compileAll(domainName, domainConfig, tempDir, { mergeKeys })
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+/**
  * Configure the CLI, register l10n commands and options, and parse process arguments.
  *
  * Sets up global options and commands (update, upload, sync, check and internal helpers),
@@ -202,7 +224,11 @@ async function run() {
         await syncTransToTarget(config, domainConfig, tag, keysPath, transDir, skipUpload, syncerOptions)
         await updateTrans(keysPath, transDir, transDir, locales, validationConfig)
 
-        await compileAll(domainName, domainConfig, transDir)
+        if (opts.source) {
+          await compileFromSource(cmd.name(), config, domainConfig, domainName, opts.source)
+        } else {
+          await compileAll(domainName, domainConfig, transDir)
+        }
       })
     })
 
@@ -502,14 +528,7 @@ async function run() {
     .action(async (opts: CompileCmdOptions, cmd: Command) => {
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig) => {
         if (opts.source) {
-          const snapshots = await fetchSourceSnapshots(cmd.name(), config, domainConfig, opts.source)
-          const mergeKeys = new Set(snapshots.map(s => s.keyName))
-          const tempDir = await materializeSnapshotsToTempDir(domainName, snapshots, domainConfig.getLocales())
-          try {
-            await compileAll(domainName, domainConfig, tempDir, { mergeKeys })
-          } finally {
-            await fsp.rm(tempDir, { recursive: true, force: true })
-          }
+          await compileFromSource(cmd.name(), config, domainConfig, domainName, opts.source)
           return
         }
         const cacheDir = domainConfig.getCacheDir()


### PR DESCRIPTION
## Summary

- `sync --source PR-N`이 `_compile --source`와 동일한 snapshot 기반 머지 경로를 타도록 변경.
- `_compile --source`의 source-aware 컴파일 로직을 `compileFromSource(...)` 헬퍼로 추출해 두 명령에서 공유.

## Why

`sync --source PR-N`은 마지막에 `mergeKeys` 없이 `compileAll`을 호출해 각 locale 출력 파일을 local cache(현재 브랜치 소스 코드에 등장하는 키로 한정)로 통째로 덮어쓰고 있었습니다. 그 결과 cache에 들어 있지 않은 다른 source(예: `main`) 소속 번역이 출력에서 조용히 삭제됐습니다. 이후 apply 워크플로의 `_compile --source` 단계는 이미 망가진 출력을 base로 읽기 때문에 복구가 불가능했습니다.

이 PR은 `sync --source`도 `_compile --source`와 동일한 snapshot 기반 컴파일 (snapshots → temp trans dir → `mergeKeys` 포함 `compileAll`) 경로를 타도록 만들어 다른 source의 번역이 보존되게 합니다.

## Follow-up

이 변경이 릴리스되면 `tpcint/workflow-storage`의 `apply-pr-l10n` 액션에서 `_compile --source` 단계는 더 이상 필요 없습니다. 별도 PR로 제거 예정 (workspace 이미 spawn 해둠).

## Test plan

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run lint`
- [ ] 머지/릴리스 후 likey-backend 등 실제 apply 워크플로에서 main-source 번역이 보존되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)