### PR TITLE
feat(compiler): append trailing newline to JSON output files

### DIFF
--- a/packages/compiler-gettext/src/compiler.ts
+++ b/packages/compiler-gettext/src/compiler.ts
@@ -41,7 +41,7 @@ export async function compileToPoJson(
     }
 
     await fsp.mkdir(targetDir, { recursive: true })
-    await fsp.writeFile(jsonPath, JSON.stringify(po, null, 2))
+    await fsp.writeFile(jsonPath, JSON.stringify(po, null, 2) + '\n')
   }
 }
 

--- a/packages/compiler-json/src/compiler.ts
+++ b/packages/compiler-json/src/compiler.ts
@@ -44,7 +44,7 @@ export async function compileToJson(
       translations[locale] = fresh
     }
   }
-  await fsp.writeFile(targetPath, JSON.stringify(translations, null, 2))
+  await fsp.writeFile(targetPath, JSON.stringify(translations, null, 2) + '\n')
 }
 
 export type JsonPluralType = 'vue-i18n' | 'node-i18n' | 'i18next'
@@ -78,9 +78,9 @@ export function compileToJsonDir(pluralType?: JsonPluralType) {
         finalJson = mergeJsonTrans(base, fresh, mergeKeys, pluralType)
       }
       if (useLocaleKey) {
-        await fsp.writeFile(jsonPath, JSON.stringify({ [locale]: finalJson }, null, 2))
+        await fsp.writeFile(jsonPath, JSON.stringify({ [locale]: finalJson }, null, 2) + '\n')
       } else {
-        await fsp.writeFile(jsonPath, JSON.stringify(finalJson, null, 2))
+        await fsp.writeFile(jsonPath, JSON.stringify(finalJson, null, 2) + '\n')
       }
     }
   }


### PR DESCRIPTION
## Summary
- compiler-json (`compileToJson`, `compileToJsonDir`)와 compiler-gettext (`compileToPoJson`)의 JSON 출력 끝에 `\n`을 붙여 일반적인 텍스트 파일 포맷 관례에 맞춤
- 바이너리 mo 출력(`compileToMo`)은 대상 외

## Test plan
- [x] `packages/compiler-json` 테스트 통과 (32 pass)
- [x] `packages/compiler-gettext` 테스트 통과 (21 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)