### PR TITLE
feat(cli): auto-load .env from cwd at CLI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Create a `.l10nrc` file in your project root:
 }
 ```
 
+> The CLI automatically loads a `.env` file from the current working directory on startup if one exists. Existing environment variables take precedence, so values exported in your shell are not overridden.
+
 ### Domain Types
 
 | Type | Description |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,6 +1680,18 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -3370,6 +3382,7 @@
         "ajv": "^8.20.0",
         "commander": "^14.0.1",
         "cosmiconfig": "^9.0.1",
+        "dotenv": "^17.4.2",
         "l10n-tools-core": "^8.2.0",
         "npmlog": "^7.0.1"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "ajv": "^8.20.0",
     "commander": "^14.0.1",
     "cosmiconfig": "^9.0.1",
+    "dotenv": "^17.4.2",
     "l10n-tools-core": "^8.2.0",
     "npmlog": "^7.0.1"
   },

--- a/packages/cli/src/dotenv-bootstrap.ts
+++ b/packages/cli/src/dotenv-bootstrap.ts
@@ -1,0 +1,3 @@
+import { config } from 'dotenv'
+
+config({ override: false, quiet: true })

--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import './dotenv-bootstrap.js'
+
 import { Command } from 'commander'
 import log from 'npmlog'
 import {


### PR DESCRIPTION
## Summary

- CLI (`packages/cli`)이 시작 시 cwd의 `.env`를 자동으로 로드합니다. 사용처 리포(예: likey-backend)에서 `TPC_AGENT_TOKEN` 등을 `.env`에 두면 매 호출마다 export하지 않아도 됩니다.
- `override: false`로 호출하므로 이미 export된 환경변수가 우선합니다. `.env`가 없어도 무에러로 통과합니다.
- 다른 모듈 평가 전에 dotenv가 적용되도록 별도 `dotenv-bootstrap.ts`를 첫 import로 분리했습니다 (ESM import 평가 순서 보장).

## Test plan

- [x] `npm run build` / `npm run lint` 통과
- [x] cwd에 `.env`가 있을 때 변수 로드 확인 (probe 스크립트)
- [x] 이미 export된 환경변수가 있을 때 export값이 우선하는지 확인 (override:false)
- [x] cwd에 `.env`가 없을 때 무에러 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)