### PR TITLE
fix(compiler): sort output keys to keep sync diffs stable

### DIFF
--- a/packages/compiler-gettext/src/compiler.test.ts
+++ b/packages/compiler-gettext/src/compiler.test.ts
@@ -5,7 +5,14 @@ import os from 'node:os'
 import path from 'node:path'
 import * as gettextParser from 'gettext-parser'
 import { CompilerConfig, type TransEntry, writeTransEntries } from 'l10n-tools-core'
-import { compileToMo, compileToPoJson, createPo, createPoEntry, mergePoTranslations } from './compiler.js'
+import {
+  compileToMo,
+  compileToPoJson,
+  createPo,
+  createPoEntry,
+  mergePoTranslations,
+  sortPoTranslations,
+} from './compiler.js'
 
 function makeTransEntry(overrides: Partial<TransEntry> = {}): TransEntry {
   return {
@@ -177,6 +184,204 @@ describe('mergePoTranslations', () => {
     ])
     mergePoTranslations(base, fresh, new Set(['drop']))
     assert.equal(base.translations[''].drop.msgstr[0], 'OLD')
+  })
+})
+
+describe('sortPoTranslations', () => {
+  it('keeps the empty msgctxt (header bucket) first and orders other msgctxts alphabetically', () => {
+    const po = createPo('d', 'en', [
+      makeTransEntry({ context: 'toolbar', key: 'a', messages: { other: 'A' } }),
+      makeTransEntry({ context: 'menu', key: 'b', messages: { other: 'B' } }),
+      makeTransEntry({ context: null, key: 'c', messages: { other: 'C' } }),
+    ])
+    const sorted = sortPoTranslations(po)
+    assert.deepEqual(Object.keys(sorted.translations), ['', 'menu', 'toolbar'])
+  })
+
+  it('orders msgids alphabetically within each msgctxt', () => {
+    const po = createPo('d', 'en', [
+      makeTransEntry({ context: null, key: 'banana', messages: { other: 'B' } }),
+      makeTransEntry({ context: null, key: 'apple', messages: { other: 'A' } }),
+      makeTransEntry({ context: 'menu', key: 'zebra', messages: { other: 'Z' } }),
+      makeTransEntry({ context: 'menu', key: 'aardvark', messages: { other: 'X' } }),
+    ])
+    const sorted = sortPoTranslations(po)
+    assert.deepEqual(Object.keys(sorted.translations['']), ['apple', 'banana'])
+    assert.deepEqual(Object.keys(sorted.translations['menu']), ['aardvark', 'zebra'])
+  })
+
+  it('handles po with only the empty msgctxt bucket (no headers entry yet)', () => {
+    // createPo lazily populates the header msgid '' under the empty msgctxt only when headers are emitted.
+    const po = createPo('d', 'en', [
+      makeTransEntry({ key: 'b', messages: { other: 'B' } }),
+      makeTransEntry({ key: 'a', messages: { other: 'A' } }),
+    ])
+    const sorted = sortPoTranslations(po)
+    assert.deepEqual(Object.keys(sorted.translations), [''])
+    assert.deepEqual(Object.keys(sorted.translations['']), ['a', 'b'])
+  })
+
+  it('preserves headers and entry values', () => {
+    const po = createPo('d', 'en', [
+      makeTransEntry({ key: 'b', messages: { other: 'B' } }),
+      makeTransEntry({ key: 'a', messages: { other: 'A' } }),
+    ])
+    const sorted = sortPoTranslations(po)
+    assert.equal(sorted.headers['Project-Id-Version'], 'd')
+    assert.equal(sorted.translations[''].a.msgstr[0], 'A')
+    assert.equal(sorted.translations[''].b.msgstr[0], 'B')
+  })
+
+  it('does not mutate the input po', () => {
+    const po = createPo('d', 'en', [
+      makeTransEntry({ context: 'toolbar', key: 'a', messages: { other: 'A' } }),
+      makeTransEntry({ context: 'menu', key: 'b', messages: { other: 'B' } }),
+    ])
+    const beforeOuter = Object.keys(po.translations)
+    sortPoTranslations(po)
+    assert.deepEqual(Object.keys(po.translations), beforeOuter)
+  })
+})
+
+describe('key order — compileToPoJson', () => {
+  it('writes msgctxts and msgids in alphabetical order in non-merge mode', async () => {
+    const dir = await makeTempDir('compile-pojson-order-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(targetDir)
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ context: 'toolbar', key: 'a', messages: { other: 'TA' } }),
+          makeTransEntry({ context: null, key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ context: 'menu', key: 'b', messages: { other: 'MB' } }),
+          makeTransEntry({ context: null, key: 'apple', messages: { other: 'A' } }),
+        ],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(targetDir), transDir)
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.deepEqual(Object.keys(written.translations), ['', 'menu', 'toolbar'])
+      assert.deepEqual(Object.keys(written.translations['']), ['apple', 'banana'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('produces the same key order in merge mode as in non-merge mode', async () => {
+    // Regression: sync --source previously preserved the base file's msgid order
+    // while `sync` produced compareEntry-sorted output, so the two paths could
+    // diverge over time. Both paths must now converge on alphabetical order.
+    const dir = await makeTempDir('compile-pojson-order-')
+    try {
+      const fullDir = path.join(dir, 'full')
+      const mergeDir = path.join(dir, 'merge')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(fullDir)
+      await fsp.mkdir(mergeDir)
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+          makeTransEntry({ key: 'cherry', messages: { other: 'C' } }),
+        ],
+      })
+
+      await compileToPoJson('d', makePoJsonConfig(fullDir), transDir)
+
+      // Seed merge target with deliberately shuffled msgid order.
+      const baseShuffled = createPo('d', 'ko', [
+        makeTransEntry({ key: 'cherry', messages: { other: 'OLD-C' } }),
+        makeTransEntry({ key: 'banana', messages: { other: 'OLD-B' } }),
+        makeTransEntry({ key: 'apple', messages: { other: 'OLD-A' } }),
+      ])
+      await fsp.writeFile(path.join(mergeDir, 'ko.json'), JSON.stringify(baseShuffled, null, 2))
+      await compileToPoJson('d', makePoJsonConfig(mergeDir), transDir, {
+        mergeKeys: new Set(['apple', 'banana', 'cherry']),
+      })
+
+      const fullJson = JSON.parse(await fsp.readFile(path.join(fullDir, 'ko.json'), 'utf-8'))
+      const mergeJson = JSON.parse(await fsp.readFile(path.join(mergeDir, 'ko.json'), 'utf-8'))
+      assert.deepEqual(
+        Object.keys(mergeJson.translations['']),
+        Object.keys(fullJson.translations['']),
+      )
+      assert.deepEqual(
+        Object.keys(mergeJson.translations['']),
+        ['apple', 'banana', 'cherry'],
+      )
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('key order — compileToMo', () => {
+  it('writes msgids in alphabetical order in non-merge mode', async () => {
+    const dir = await makeTempDir('compile-mo-order-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+          makeTransEntry({ key: 'cherry', messages: { other: 'C' } }),
+        ],
+      })
+
+      await compileToMo('d', makeMoConfig(targetDir), transDir)
+
+      const buf = await fsp.readFile(path.join(targetDir, 'ko', 'LC_MESSAGES', 'd.mo'))
+      const parsed = gettextParser.mo.parse(buf)
+      const msgids = Object.keys(parsed.translations['']).filter(id => id !== '')
+      assert.deepEqual(msgids, ['apple', 'banana', 'cherry'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('produces the same .mo bytes whether compiled fresh or via merge from a shuffled base', async () => {
+    // End-to-end regression: with sortPoTranslations applied on both paths, the
+    // .mo output is byte-identical regardless of how the base file was ordered.
+    const dir = await makeTempDir('compile-mo-order-')
+    try {
+      const fullDir = path.join(dir, 'full')
+      const mergeDir = path.join(dir, 'merge')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+        ],
+      })
+
+      await compileToMo('d', makeMoConfig(fullDir), transDir)
+
+      // Seed merge target with shuffled msgid order.
+      const moDir = path.join(mergeDir, 'ko', 'LC_MESSAGES')
+      await fsp.mkdir(moDir, { recursive: true })
+      const baseShuffled = createPo('d', 'ko', [
+        makeTransEntry({ key: 'banana', messages: { other: 'OLD-B' } }),
+        makeTransEntry({ key: 'apple', messages: { other: 'OLD-A' } }),
+      ])
+      await fsp.writeFile(path.join(moDir, 'd.mo'), gettextParser.mo.compile(baseShuffled))
+
+      await compileToMo('d', makeMoConfig(mergeDir), transDir, {
+        mergeKeys: new Set(['apple', 'banana']),
+      })
+
+      const fullBytes = await fsp.readFile(path.join(fullDir, 'ko', 'LC_MESSAGES', 'd.mo'))
+      const mergeBytes = await fsp.readFile(path.join(moDir, 'd.mo'))
+      assert.deepEqual(Buffer.from(mergeBytes), Buffer.from(fullBytes))
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/compiler-gettext/src/compiler.ts
+++ b/packages/compiler-gettext/src/compiler.ts
@@ -39,6 +39,7 @@ export async function compileToPoJson(
       const base = await readPoJsonIfExists(jsonPath, domainName, locale)
       po = mergePoTranslations(base, po, mergeKeys)
     }
+    po = sortPoTranslations(po)
 
     await fsp.mkdir(targetDir, { recursive: true })
     await fsp.writeFile(jsonPath, JSON.stringify(po, null, 2) + '\n')
@@ -71,6 +72,7 @@ export async function compileToMo(
       const base = await readMoIfExists(moPath, domainName, locale)
       po = mergePoTranslations(base, po, mergeKeys)
     }
+    po = sortPoTranslations(po)
     const output = gettextParser.mo.compile(po)
 
     await fsp.mkdir(moDir, { recursive: true })
@@ -171,6 +173,38 @@ export function mergePoTranslations(
   }
 
   return merged
+}
+
+/**
+ * Returns a copy of `po` with `translations` reinserted in a deterministic order:
+ * the empty msgctxt (header bucket) first, then remaining msgctxts alphabetically;
+ * within each msgctxt, msgids are reinserted in alphabetical order. This matches
+ * the order produced by a non-merge sync, where input trans entries are already
+ * sorted by `compareEntry` (context-null first, then context alphabetically; key
+ * alphabetically within each group).
+ *
+ * @internal exported for testing
+ */
+export function sortPoTranslations(po: GetTextTranslations): GetTextTranslations {
+  const sorted: GetTextTranslations['translations'] = {}
+  const msgctxts = Object.keys(po.translations)
+  if (msgctxts.includes('')) {
+    sorted[''] = sortMsgidEntries(po.translations[''])
+  }
+  for (const msgctxt of msgctxts.filter(c => c !== '').sort()) {
+    sorted[msgctxt] = sortMsgidEntries(po.translations[msgctxt])
+  }
+  return { ...po, translations: sorted }
+}
+
+function sortMsgidEntries(
+  entries: { [msgid: string]: GetTextTranslation },
+): { [msgid: string]: GetTextTranslation } {
+  const sorted: { [msgid: string]: GetTextTranslation } = {}
+  for (const msgid of Object.keys(entries).sort()) {
+    sorted[msgid] = entries[msgid]
+  }
+  return sorted
 }
 
 async function readPoJsonIfExists(

--- a/packages/compiler-json/src/compiler.test.ts
+++ b/packages/compiler-json/src/compiler.test.ts
@@ -4,7 +4,14 @@ import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { CompilerConfig, type TransEntry, writeTransEntries } from 'l10n-tools-core'
-import { buildJsonTrans, compileToJson, compileToJsonDir, jsonKeyMatchesMergeKeys, mergeJsonTrans } from './compiler.js'
+import {
+  buildJsonTrans,
+  compileToJson,
+  compileToJsonDir,
+  jsonKeyMatchesMergeKeys,
+  mergeJsonTrans,
+  sortJsonTrans,
+} from './compiler.js'
 
 function makeTransEntry(overrides: Partial<TransEntry> = {}): TransEntry {
   return {
@@ -224,6 +231,222 @@ describe('mergeJsonTrans', () => {
       drop_one: 'NEW-one',
       drop_other: 'NEW-many',
     })
+  })
+})
+
+describe('sortJsonTrans', () => {
+  it('reinserts keys in alphabetical order', () => {
+    const sorted = sortJsonTrans({ b: 'B', a: 'A', c: 'C' })
+    assert.deepEqual(Object.keys(sorted), ['a', 'b', 'c'])
+  })
+
+  it('preserves the value for each key', () => {
+    const sorted = sortJsonTrans({ b: 'B', a: 'A' })
+    assert.deepEqual(sorted, { a: 'A', b: 'B' })
+  })
+
+  it('does not mutate the input object', () => {
+    const input = { b: 'B', a: 'A' }
+    sortJsonTrans(input)
+    assert.deepEqual(Object.keys(input), ['b', 'a'])
+  })
+
+  it('handles object values (node-i18n shape)', () => {
+    const sorted = sortJsonTrans({ b: { other: 'B' }, a: { one: '1', other: 'A' } })
+    assert.deepEqual(Object.keys(sorted), ['a', 'b'])
+  })
+})
+
+describe('key order — compileToJson', () => {
+  it('writes keys in alphabetical order in non-merge mode', async () => {
+    const dir = await makeTempDir('compile-json-order-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+          makeTransEntry({ key: 'cherry', messages: { other: 'C' } }),
+        ],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir)
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(Object.keys(written.ko), ['apple', 'banana', 'cherry'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('produces the same key order in merge mode as in non-merge mode', async () => {
+    // Regression: `sync --source` (merge mode) used to leave merged keys at the
+    // end of the object, producing a different order than `sync` (non-merge).
+    // Both paths must converge on the same alphabetical key order.
+    const dir = await makeTempDir('compile-json-order-')
+    try {
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+          makeTransEntry({ key: 'cherry', messages: { other: 'C' } }),
+        ],
+      })
+
+      const fullPath = path.join(dir, 'full.json')
+      await compileToJson('d', makeJsonConfig(fullPath), transDir)
+
+      // Merge path: start with a base file whose keys are deliberately in a
+      // different (non-alphabetical) order, then merge in the same set.
+      const mergePath = path.join(dir, 'merge.json')
+      await fsp.writeFile(mergePath, JSON.stringify({
+        ko: { cherry: 'OLD-C', banana: 'OLD-B', apple: 'OLD-A' },
+      }, null, 2))
+      await compileToJson('d', makeJsonConfig(mergePath), transDir, {
+        mergeKeys: new Set(['apple', 'banana', 'cherry']),
+      })
+
+      const fullJson = JSON.parse(await fsp.readFile(fullPath, 'utf-8'))
+      const mergeJson = JSON.parse(await fsp.readFile(mergePath, 'utf-8'))
+      assert.deepEqual(Object.keys(mergeJson.ko), Object.keys(fullJson.ko))
+      assert.deepEqual(Object.keys(mergeJson.ko), ['apple', 'banana', 'cherry'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('sorts a partial merge so PR keys interleave with preserved base keys', async () => {
+    const dir = await makeTempDir('compile-json-order-')
+    try {
+      const targetPath = path.join(dir, 'out.json')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await fsp.writeFile(targetPath, JSON.stringify({
+        ko: { cherry: 'C', apple: 'A' },
+      }, null, 2))
+      await writeTransFiles(transDir, {
+        ko: [makeTransEntry({ key: 'banana', messages: { other: 'B' } })],
+      })
+
+      await compileToJson('d', makeJsonConfig(targetPath), transDir, {
+        mergeKeys: new Set(['banana']),
+      })
+
+      const written = JSON.parse(await fsp.readFile(targetPath, 'utf-8'))
+      assert.deepEqual(Object.keys(written.ko), ['apple', 'banana', 'cherry'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('key order — compileToJsonDir', () => {
+  it('writes keys in alphabetical order in non-merge mode', async () => {
+    const dir = await makeTempDir('compile-jsondir-order-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+        ],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir), transDir)
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.deepEqual(Object.keys(written), ['apple', 'banana'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('matches non-merge order in merge mode despite a shuffled base file', async () => {
+    const dir = await makeTempDir('compile-jsondir-order-')
+    try {
+      const fullDir = path.join(dir, 'full')
+      const mergeDir = path.join(dir, 'merge')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(fullDir)
+      await fsp.mkdir(mergeDir)
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+        ],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(fullDir), transDir)
+
+      await fsp.writeFile(path.join(mergeDir, 'ko.json'),
+        JSON.stringify({ banana: 'OLD-B', apple: 'OLD-A' }, null, 2))
+      await compileToJsonDir()('d', makeJsonDirConfig(mergeDir), transDir, {
+        mergeKeys: new Set(['apple', 'banana']),
+      })
+
+      const fullJson = JSON.parse(await fsp.readFile(path.join(fullDir, 'ko.json'), 'utf-8'))
+      const mergeJson = JSON.parse(await fsp.readFile(path.join(mergeDir, 'ko.json'), 'utf-8'))
+      assert.deepEqual(Object.keys(mergeJson), Object.keys(fullJson))
+      assert.deepEqual(Object.keys(mergeJson), ['apple', 'banana'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('sorts i18next plural-suffixed keys alphabetically alongside non-plural keys', async () => {
+    const dir = await makeTempDir('compile-jsondir-order-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        en: [
+          makeTransEntry({ key: 'item', messages: { one: '1', other: 'many' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+          makeTransEntry({ key: 'zebra', messages: { other: 'Z' } }),
+        ],
+      })
+
+      await compileToJsonDir('i18next')('d', new CompilerConfig({
+        'type': 'i18next',
+        'target-dir': targetDir,
+      } as never), transDir)
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'en.json'), 'utf-8'))
+      assert.deepEqual(Object.keys(written), ['apple', 'item_one', 'item_other', 'zebra'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves the locale key wrapper when sorting', async () => {
+    const dir = await makeTempDir('compile-jsondir-order-')
+    try {
+      const targetDir = path.join(dir, 'out')
+      const transDir = path.join(dir, 'trans')
+      await fsp.mkdir(transDir)
+      await writeTransFiles(transDir, {
+        ko: [
+          makeTransEntry({ key: 'banana', messages: { other: 'B' } }),
+          makeTransEntry({ key: 'apple', messages: { other: 'A' } }),
+        ],
+      })
+
+      await compileToJsonDir()('d', makeJsonDirConfig(targetDir, true), transDir)
+
+      const written = JSON.parse(await fsp.readFile(path.join(targetDir, 'ko.json'), 'utf-8'))
+      assert.deepEqual(Object.keys(written), ['ko'])
+      assert.deepEqual(Object.keys(written.ko), ['apple', 'banana'])
+    } finally {
+      await fsp.rm(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/compiler-json/src/compiler.ts
+++ b/packages/compiler-json/src/compiler.ts
@@ -43,6 +43,7 @@ export async function compileToJson(
     } else {
       translations[locale] = fresh
     }
+    translations[locale] = sortJsonTrans(translations[locale])
   }
   await fsp.writeFile(targetPath, JSON.stringify(translations, null, 2) + '\n')
 }
@@ -77,6 +78,7 @@ export function compileToJsonDir(pluralType?: JsonPluralType) {
         const base = await readJsonDirBase(jsonPath, useLocaleKey, locale)
         finalJson = mergeJsonTrans(base, fresh, mergeKeys, pluralType)
       }
+      finalJson = sortJsonTrans(finalJson)
       if (useLocaleKey) {
         await fsp.writeFile(jsonPath, JSON.stringify({ [locale]: finalJson }, null, 2) + '\n')
       } else {
@@ -177,6 +179,21 @@ export function mergeJsonTrans(
     result[key] = value
   }
   return result
+}
+
+/**
+ * Returns a copy of `trans` with keys reinserted in alphabetical order so the
+ * compiled output is deterministic regardless of how merge mode shuffled the
+ * underlying object.
+ *
+ * @internal exported for testing
+ */
+export function sortJsonTrans(trans: JsonTrans): JsonTrans {
+  const sorted: JsonTrans = {}
+  for (const key of Object.keys(trans).sort()) {
+    sorted[key] = trans[key]
+  }
+  return sorted
 }
 
 async function readJsonIfExists(filePath: string): Promise<unknown | null> {


### PR DESCRIPTION
## Summary

- `sync --source xxx` 머지 경로가 출력 객체에 매번 머지 키를 끝으로 재삽입해, 같은 trans 입력에도 매 sync마다 키 순서 diff가 발생하던 문제 수정
- `compiler-json` / `compiler-gettext`의 직렬화 직전에 키를 결정적 순서로 정렬하여 비머지 `sync`와 `sync --source`가 같은 결과로 수렴
- 비머지 경로 출력은 사실상 동일 (`compareEntry`로 이미 정렬되어 있었으므로). 예외: i18next + 3-form 이상 locale(ru 등)에서 첫 sync 1회성 정렬 diff

## Test plan

- [x] `compiler-json`: `sortJsonTrans` 단위 테스트, 비머지 vs 머지 경로 키 순서 일치 회귀 테스트, i18next plural-suffix / `useLocaleKey` wrapper 정렬 확인
- [x] `compiler-gettext`: `sortPoTranslations` 단위 테스트, 비머지 vs 머지 경로 키 순서 일치 회귀 테스트, **셔플된 base에서 머지/비머지 .mo 바이트 동일성** 회귀 테스트
- [x] 전체 워크스페이스 테스트 + 린트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)