### PR TITLE
fix: propagate new Android names to localized strings.xml on PR apply

### DIFF
--- a/packages/plugin-android/src/compiler.test.ts
+++ b/packages/plugin-android/src/compiler.test.ts
@@ -281,6 +281,55 @@ describe('android compiler test', () => {
       assert.match(newDstXml, /<string name="newly_added">신규<\/string>/)
     })
 
+    it('appends a new entry with the surrounding indentation and keeps </resources> on its own line', async () => {
+      // Regression: previously the append path simply pushed the new node, so
+      // </string><string>…</string></resources> ran together on a single line.
+      const transEntries: TransEntry[] = [
+        { context: 'cancel', key: '취소', messages: { other: 'Cancel' }, flag: null },
+        { context: 'prsnt_membership_coupon_issue_cancel', key: '취소', messages: { other: 'Cancel' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cancel">취소</string>
+    <string name="prsnt_membership_coupon_issue_cancel">취소</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cancel">Cancel</string>
+</resources>`
+
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cancel">Cancel</string>
+    <string name="prsnt_membership_coupon_issue_cancel">Cancel</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
+      assert.equal(newDstXml, expected)
+    })
+
+    it('appends into an empty <resources></resources> with a newline before the closing tag', async () => {
+      // Regression: previously an empty dst produced `<resources><string …/></resources>`
+      // on one line. The append path now lays out indentation and a trailing newline.
+      const transEntries: TransEntry[] = [
+        { context: 'cancel', key: '취소', messages: { other: 'Cancel' }, flag: null },
+      ]
+      const srcXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cancel">취소</string>
+</resources>`
+      const dstXml = `<?xml version="1.0" encoding="utf-8"?>
+<resources></resources>`
+
+      const expected = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="cancel">Cancel</string>
+</resources>`
+
+      const newDstXml = await generateAndroidXml('en', transEntries, srcXml, dstXml, { merge: true })
+      assert.equal(newDstXml, expected)
+    })
+
     it('updates a PR-N plurals entry and preserves other plurals from dst', async () => {
       const transEntries: TransEntry[] = [
         { context: 'item_plurals', key: '%d item', messages: { one: '%d 항목 NEW', other: '%d 항목들 NEW' }, flag: null },

--- a/packages/plugin-android/src/compiler.ts
+++ b/packages/plugin-android/src/compiler.ts
@@ -385,7 +385,28 @@ function replaceOrAppendByName(resources: XMLNode[], name: string, newNode: XMLT
     resources[idx] = newNode
     return
   }
-  resources.push(newNode)
+  // Append: keep <resources> whitespace stable. Insert before any trailing whitespace
+  // text node (so </resources> stays on its own line), preceded by an inter-element
+  // whitespace node sampled from the existing children (so the new entry lines up
+  // with the surrounding indentation).
+  const indent = sampleInterElementWhitespace(resources) ?? '\n    '
+  const lastIdx = resources.length - 1
+  const last = lastIdx >= 0 ? resources[lastIdx] : null
+  if (last != null && isTextNode(last)) {
+    resources.splice(lastIdx, 0, createTextNode(indent), newNode)
+  } else {
+    resources.push(createTextNode(indent), newNode, createTextNode('\n'))
+  }
+}
+
+function sampleInterElementWhitespace(resources: XMLNode[]): string | null {
+  for (const node of resources) {
+    if (!isTextNode(node)) continue
+    // Look for an indentation pattern (newline followed by non-empty whitespace).
+    // Skip pure '\n' which is typical of the closing </resources> margin.
+    if (/^\n[ \t]+$/.test(node['#text'])) return node['#text']
+  }
+  return null
 }
 
 function removeFromResourcesByName(resources: XMLNode[], name: string): void {

--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -89,7 +89,7 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.deepEqual(tagPair(bye), [{ tag: 'web', source: 'main' }])
   })
 
-  it('adds tag to existing key without duplicating', async () => {
+  it('claims (tag, source) when another source already owns the same tag', async () => {
     await seedKeys(projectId!, [{
       keyName: 'shared.key',
       tags: [{ tag: 'web', source: 'other' }],
@@ -101,10 +101,13 @@ describe('syncTransToL10nStorage (e2e)', () => {
     )
 
     const [k] = await apiClient.listAllKeysToServe(projectId!)
-    // 같은 tag가 다른 source로 이미 있으면 syncer는 태그를 또 붙이지 않는다.
-    assert.equal(k.tags.length, 1)
-    assert.equal(k.tags[0].tag, 'web')
-    assert.equal(k.tags[0].source, 'other')
+    // Per-source ownership: 'main' references the key locally so it claims its own
+    // (tag, source) tag alongside the existing one — otherwise the source filter for
+    // 'main' would not include this key.
+    const pairs = k.tags.map(t => ({ tag: t.tag, source: t.source }))
+    assert.equal(pairs.length, 2)
+    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'other'))
+    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'main'))
   })
 
   it('downloads server translations into local trans entries', async () => {

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -274,6 +274,30 @@ describe('buildKeyChanges', () => {
 
     assert.equal(updatingKeys.length, 0)
   })
+
+  it('Pass 1: should be skipped for non-authoritative source (add-only)', () => {
+    // A PR source claimed the key on a previous sync. On a later PR sync where the PR's
+    // local no longer references one of the contexts, Pass 1 must NOT strip it: contexts
+    // are shared across sources via tag-level metadata, so the PR could otherwise remove
+    // a context that 'main' still uses. Only the authoritative source may clean up.
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      'shared.key': createL10nKey('shared.key', {
+        id: 'key-1',
+        tags: [
+          { tag: 'backend', source: 'main' },
+          { tag: 'backend', source: 'PR-7' },
+        ],
+        metadata: [{ tag: 'backend', metaKey: 'context', metaValue: '["main_ctx", "pr_ctx"]' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'PR-7', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
 })
 
 describe('updateTransEntries', () => {

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -53,11 +53,31 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(creatingKeys[0].tags, [{ tag: 'backend', source: 'main' }])
   })
 
-  it('should not add tag when key already has the tag with any source', () => {
+  it('should add tag when key has the tag with another source (per-source tagging)', () => {
+    // A PR referencing a key that main already owns must still claim its own
+    // (tag, source) ownership; otherwise the source filter cannot return the key
+    // back to this PR's apply step.
     const keyEntries = [createKeyEntry('existing.key')]
     const listedKeyMap = {
       'existing.key': createL10nKey('existing.key', {
         tags: [{ tag: 'backend', source: 'main' }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'backend', source: 'PR-123' }])
+  })
+
+  it('should not add tag when key already has the tag with the same source', () => {
+    const keyEntries = [createKeyEntry('existing.key')]
+    const listedKeyMap = {
+      'existing.key': createL10nKey('existing.key', {
+        tags: [{ tag: 'backend', source: 'PR-123' }],
       }),
     }
 
@@ -84,6 +104,33 @@ describe('buildKeyChanges', () => {
     assert.equal(creatingKeys.length, 0)
     assert.equal(updatingKeys.length, 1)
     assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'backend', source: 'main' }])
+  })
+
+  it('should add (tag, source) when a new context is added to an existing keyName', () => {
+    // Regression: a PR that adds a new Android `name` reusing existing translation
+    // text must tag the server key with (tag, source) so that the PR's source
+    // filter can include the key for compile-from-source. Previously only the
+    // context metadata was updated, leaving the source filter blind to this key.
+    const keyEntries = [
+      createKeyEntry('취소', { context: 'prsnt_membership_coupon_issue_cancel' }),
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['cancel']) }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-99', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'android-likey', source: 'PR-99' }])
+    const contextMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'context')
+    assert.ok(contextMeta != null)
+    assert.deepEqual(JSON.parse(contextMeta.metaValue), ['cancel', 'prsnt_membership_coupon_issue_cancel'])
   })
 
   it('should attach suggestions for new keys with translations', () => {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -54,7 +54,12 @@ export async function syncTransToL10nStorage(
 ) {
   const storageConfig = config.getL10nStorageConfig()
   const projectId = storageConfig.getProjectId()
-  const source = options?.source ?? storageConfig.getSource()
+  const configSource = storageConfig.getSource()
+  const source = options?.source ?? configSource
+  // The configured source (e.g. 'main') is the authoritative one that owns metadata cleanup.
+  // Ephemeral sources like a PR scope must be add-only so they cannot strip contexts that
+  // other sources (notably 'main') still use — context metadata is shared per tag.
+  const isAuthoritativeSource = source === configSource
   const url = storageConfig.getUrl()
 
   const token = process.env.TPC_AGENT_TOKEN
@@ -76,7 +81,7 @@ export async function syncTransToL10nStorage(
 
   // 2. 로컬과 비교하여 create/update 대상 분류
   const { creatingKeys, updatingKeys } = buildKeyChanges(
-    source, tag, keyEntries, allTransData, listedKeyMap, localeSyncMap, options,
+    source, tag, keyEntries, allTransData, listedKeyMap, localeSyncMap, options, isAuthoritativeSource,
   )
 
   // 3. 서버 번역을 로컬에 반영
@@ -163,6 +168,7 @@ export function buildKeyChanges(
   listedKeyMap: { [keyName: string]: L10nKeyToServe },
   localeSyncMap?: { [locale: string]: string },
   options?: SyncerOptions,
+  isAuthoritativeSource: boolean = true,
 ): {
   creatingKeys: CreateL10nKeyInput[],
   updatingKeys: UpdateL10nKeyInput[],
@@ -175,29 +181,34 @@ export function buildKeyChanges(
   const globalMetadata = options?.globalMetadata
   const tagMetadata = options?.tagMetadata
 
-  // Pass 1: 서버에 있고 우리 source 태그가 있는 키 → 로컬에 없는 context 제거
-  for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
-    if (!hasTag(listedKey.tags, tag, source)) continue
+  // Pass 1: 서버에 있고 우리 source 태그가 있는 키 → 로컬에 없는 context 제거.
+  // Context metadata는 (tag) 단위로 모든 source가 공유하므로, 권위가 없는 source(예: PR-N)가
+  // cleanup을 수행하면 다른 source의 context를 의도치 않게 지울 수 있다.
+  // 따라서 권위 source(config의 source)일 때만 Pass 1을 활성화한다. 임시 source는 add-only.
+  if (isAuthoritativeSource) {
+    for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
+      if (!hasTag(listedKey.tags, tag, source)) continue
 
-    for (const keyContext of getContextsFromMetadata(listedKey.metadata, tag)) {
-      const keyEntry = keys.find(keyContext, keyName)
-      if (keyEntry == null) {
-        let updating = updatingKeyMap[keyName]
-        if (!updating) {
-          updating = { keyId: listedKey.id }
-          updatingKeyMap[keyName] = updating
-        }
-        const contextMeta = buildContextMetadataRemoving(listedKey.metadata, tag, keyContext)
-        if (contextMeta) {
-          pushSetMetadata(updating, contextMeta)
-        }
-        // 모든 context가 제거되면 태그도 제거
-        const remaining = getContextsFromMetadata(
-          mergeMetadata(listedKey.metadata, updating.setMetadata ?? []),
-          tag,
-        )
-        if (remaining.length === 0) {
-          pushRemoveTag(updating, { tag, source })
+      for (const keyContext of getContextsFromMetadata(listedKey.metadata, tag)) {
+        const keyEntry = keys.find(keyContext, keyName)
+        if (keyEntry == null) {
+          let updating = updatingKeyMap[keyName]
+          if (!updating) {
+            updating = { keyId: listedKey.id }
+            updatingKeyMap[keyName] = updating
+          }
+          const contextMeta = buildContextMetadataRemoving(listedKey.metadata, tag, keyContext)
+          if (contextMeta) {
+            pushSetMetadata(updating, contextMeta)
+          }
+          // 모든 context가 제거되면 태그도 제거
+          const remaining = getContextsFromMetadata(
+            mergeMetadata(listedKey.metadata, updating.setMetadata ?? []),
+            tag,
+          )
+          if (remaining.length === 0) {
+            pushRemoveTag(updating, { tag, source })
+          }
         }
       }
     }

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -92,10 +92,6 @@ function hasTag(tags: L10nKeyTag[], tag: string, source: string): boolean {
   return tags.some(t => t.tag === tag && t.source === source)
 }
 
-function hasTagName(tags: L10nKeyTag[], tag: string): boolean {
-  return tags.some(t => t.tag === tag)
-}
-
 function hasTranslation(key: L10nKeyToServe, locale: string): boolean {
   return key.translations.some(t => t.locale === locale)
 }
@@ -213,7 +209,7 @@ export function buildKeyChanges(
     const listedKey = listedKeyMap[entryKey]
 
     if (listedKey != null) {
-      const needsTagAdd = !hasTagName(listedKey.tags, tag)
+      const needsTagAdd = !hasTag(listedKey.tags, tag, source)
       const needsContextUpdate = !metadataContainsContext(listedKey.metadata, tag, keyEntry.context)
       const needsDescriptionUpdate = !metadataContainsDescription(listedKey.metadata, tag, keyEntry.comments)
 


### PR DESCRIPTION
## Summary

Joe와 chucky가 Slack에서 보고한 두 가지 회귀를 묶어서 수정합니다:

1. **새 Android `name`이 PR apply 후 localized `strings.xml`에 반영되지 않음** — l10n-storage syncer가 기존 keyName에 새 context를 추가할 때 `(tag, source=PR-N)` 태그를 같이 붙이지 않아, source 필터가 해당 키를 못 찾고 `compileFromSource`가 새 `<string name>`을 추가하지 못했습니다.
2. **merge-mode compile이 `<string>` 사이 줄바꿈/들여쓰기를 깨뜨림** — `replaceOrAppendByName`의 단순 `push(newNode)`가 element 사이/`</resources>` 직전의 whitespace 텍스트 노드를 챙기지 않아 `</string><string>…</string></resources>`처럼 한 줄로 붙었습니다.

## Changes

- `fix(syncer-l10n-storage): claim (tag, source) on every key the source uses` — `hasTagName`(이름만) 대신 `hasTag(tag, source)` strict 체크로 변경. 기존 keyName에 새 context가 추가되거나 단순 참조만 추가되어도 source ownership이 함께 기록됨
- `fix(syncer-l10n-storage): skip Pass 1 cleanup for non-authoritative sources` — context metadata가 (tag) 단위로 공유되는 한계 때문에, 권위 source(config의 `l10n-storage.source`, 기본 `'main'`)일 때만 Pass 1 cleanup을 수행. PR-N 같은 임시 source는 add-only로 동작
- `fix(plugin-android): preserve whitespace when appending to merged strings.xml` — append 시 들여쓰기 텍스트 노드를 새 element 앞에 끼우고, dst의 trailing whitespace 노드 앞에 삽입해 closing 태그가 자기 줄에 유지되도록

## Test plan

- [x] `syncer-l10n-storage` unit tests pass (30, +3 신규 회귀 케이스)
- [x] `plugin-android` unit tests pass (38, +2 신규 회귀 케이스)
- [x] 재현 시나리오(`<string name="cancel">취소</string>`에 새 `<string name="prsnt_...">취소</string>` 추가)로 fix 후 정상 출력 확인
- [ ] e2e 검증: 실제 `apply-pr-l10n` 워크플로우에서 likey-android 같은 케이스로 확인 (Joe/chucky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)