### PR TITLE
fix(syncer-l10n-storage): accumulate metadata across multi-context keyNames

### DIFF
--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -395,6 +395,54 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys.length, 0)
   })
 
+  it('Pass 2: clears stale references metadata when this sync produces no refs but server has stale ones', () => {
+    // 이전 sync에 file:loc가 남아 있고, 이번 sync의 entries에는 references가 없는 경우,
+    // 기존 메타가 그대로 남으면 stale `file:loc`가 계속 보존되므로 빈 array로 명시적 cleanup이 필요하다.
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), references: [] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [
+          { tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) },
+          {
+            tag: 'android-likey',
+            metaKey: 'references',
+            metaValue: JSON.stringify([{ file: 'app/values/strings.xml', loc: '12' }]),
+          },
+        ],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    const refsMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'references')
+    assert.ok(refsMeta != null)
+    assert.deepEqual(JSON.parse(refsMeta.metaValue), [])
+  })
+
+  it('Pass 2: does not touch references metadata when both this sync and server have no refs', () => {
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), references: [] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
+
   it('Pass 2: accumulates contexts when same keyName appears with multiple contexts (new key)', () => {
     // 새 키 생성 분기에서도 같은 keyName의 여러 entry가 group으로 처리되어 모든 context가 들어가야 한다.
     const keyEntries = [

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -275,6 +275,143 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys.length, 0)
   })
 
+  it('Pass 2: accumulates contexts when same keyName appears with multiple contexts (existing key)', () => {
+    // Android에서 동일 원문이 여러 <string name>에 쓰이는 흔한 패턴. 한 번의 sync에서 같은 keyName이
+    // 서로 다른 context로 여러 KeyEntry로 들어와도 setMetadata의 (tag, 'context') 엔트리가 서로를
+    // 덮어쓰지 않고 두 context가 모두 누적되어야 한다.
+    const keyEntries = [
+      createKeyEntry('취소', { context: 'a:cancel_button' }),
+      createKeyEntry('취소', { context: 'b:dialog_cancel' }),
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['legacy_ctx']) }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    const contextMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'context')
+    assert.ok(contextMeta != null)
+    assert.deepEqual(
+      JSON.parse(contextMeta.metaValue),
+      ['legacy_ctx', 'a:cancel_button', 'b:dialog_cancel'],
+    )
+  })
+
+  it('Pass 2: addTags pushes (tag, source) only once across multiple entries with same keyName', () => {
+    // 같은 keyName이 여러 context로 들어와도 addTags에 동일 (tag, source)가 여러 번 push되면 안 된다.
+    const keyEntries = [
+      createKeyEntry('취소', { context: 'a:one' }),
+      createKeyEntry('취소', { context: 'b:two' }),
+      createKeyEntry('취소', { context: 'c:three' }),
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'PR-77', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'android-likey', source: 'PR-77' }])
+  })
+
+  it('Pass 2: merges description comments across multiple entries with same keyName', () => {
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), comments: ['Used on the cancel button'] },
+      { ...createKeyEntry('취소', { context: 'b' }), comments: ['Also used in confirmation dialog'] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'description', metaValue: 'Pre-existing note' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    const descMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'description')
+    assert.ok(descMeta != null)
+    assert.equal(
+      descMeta.metaValue,
+      'Pre-existing note\nUsed on the cancel button\nAlso used in confirmation dialog',
+    )
+  })
+
+  it('Pass 2: merges references across multiple entries with same keyName into one setMetadata', () => {
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), references: [{ file: 'app/values/strings.xml', loc: '12' }] },
+      { ...createKeyEntry('취소', { context: 'b' }), references: [{ file: 'lib/values/strings.xml', loc: '7' }] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    const refsMetaList = updatingKeys[0].setMetadata?.filter(m => m.metaKey === 'references') ?? []
+    assert.equal(refsMetaList.length, 1)
+    assert.deepEqual(JSON.parse(refsMetaList[0].metaValue), [
+      { file: 'app/values/strings.xml', loc: '12' },
+      { file: 'lib/values/strings.xml', loc: '7' },
+    ])
+  })
+
+  it('Pass 2: skips references setMetadata when value is unchanged', () => {
+    const sameRefs = [{ file: 'app/values/strings.xml', loc: '12' }]
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), references: sameRefs },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [
+          { tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) },
+          { tag: 'android-likey', metaKey: 'references', metaValue: JSON.stringify(sameRefs) },
+        ],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('Pass 2: accumulates contexts when same keyName appears with multiple contexts (new key)', () => {
+    // 새 키 생성 분기에서도 같은 keyName의 여러 entry가 group으로 처리되어 모든 context가 들어가야 한다.
+    const keyEntries = [
+      createKeyEntry('취소', { context: 'a:one' }),
+      createKeyEntry('취소', { context: 'b:two' }),
+    ]
+
+    const { creatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, {},
+    )
+
+    assert.equal(creatingKeys.length, 1)
+    const contextMeta = creatingKeys[0].metadata?.find(m => m.metaKey === 'context')
+    assert.ok(contextMeta != null)
+    assert.deepEqual(JSON.parse(contextMeta.metaValue), ['a:one', 'b:two'])
+  })
+
   it('Pass 1: should be skipped for non-authoritative source (add-only)', () => {
     // A PR source claimed the key on a previous sync. On a later PR sync where the PR's
     // local no longer references one of the contexts, Pass 1 must NOT strip it: contexts

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -260,11 +260,13 @@ export function buildKeyChanges(
 
       // references는 group의 모든 entry refs를 합산해 매 sync 단위로 replace한다.
       // 이전 sync의 references는 base로 누적시키지 않는다(file:line이 stale일 수 있음).
+      // 이번 sync에서 refs가 0건이지만 서버에 기존 entry가 있으면, stale `file:loc`이 남지 않도록
+      // 빈 array("[]")로 명시적으로 replace한다.
       const mergedRefs = mergeReferences(entries.flatMap(e => e.references))
-      const refMeta = buildReferencesMetadata(tag, mergedRefs)
+      const mergedRefsValue = JSON.stringify(mergedRefs)
       const existingRefEntry = listedKey.metadata.find(m => m.tag === tag && m.metaKey === 'references')
-      const refsChanged = refMeta != null
-        && (existingRefEntry == null || existingRefEntry.metaValue !== refMeta.metaValue)
+      const refsChanged = (mergedRefs.length > 0 || existingRefEntry != null)
+        && (existingRefEntry == null || existingRefEntry.metaValue !== mergedRefsValue)
 
       const needsTagAdd = !hasTag(listedKey.tags, tag, source)
 
@@ -280,8 +282,8 @@ export function buildKeyChanges(
         for (const u of metaUpdates) {
           pushSetMetadata(updating, u)
         }
-        if (refsChanged && refMeta) {
-          pushSetMetadata(updating, refMeta)
+        if (refsChanged) {
+          pushSetMetadata(updating, { tag, metaKey: 'references', metaValue: mergedRefsValue })
         }
       }
     } else {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -3,6 +3,7 @@ import {
   type DomainConfig,
   EntryCollection,
   type KeyEntry,
+  type KeyReference,
   type L10nConfig,
   type SyncerOptions,
   type TransEntry,
@@ -26,8 +27,6 @@ import {
   buildReferencesMetadata,
   buildTagMetadata,
   getContextsFromMetadata,
-  metadataContainsContext,
-  metadataContainsDescription,
 } from './metadata.js'
 
 function assertBijectiveLocaleSyncMap(localeSyncMap: { [locale: string]: string }): void {
@@ -159,6 +158,19 @@ function mergeMetadata(existing: L10nKeyMetadata[], updates: L10nKeyMetadata[]):
   return result
 }
 
+function mergeReferences(refs: KeyReference[]): KeyReference[] {
+  const seen = new Set<string>()
+  const result: KeyReference[] = []
+  for (const r of refs) {
+    const k = `${r.file}\0${r.loc ?? ''}`
+    if (!seen.has(k)) {
+      seen.add(k)
+      result.push(r)
+    }
+  }
+  return result
+}
+
 /** @internal exported for testing */
 export function buildKeyChanges(
   source: string,
@@ -214,17 +226,49 @@ export function buildKeyChanges(
     }
   }
 
-  // Pass 2: 로컬 keyEntries → 새 키 생성 또는 기존 키 업데이트
-  for (const keyEntry of keyEntries) {
-    const entryKey = keyEntry.key
+  // Pass 2: 로컬 keyEntries → 새 키 생성 또는 기존 키 업데이트.
+  // 같은 keyName이 서로 다른 context로 여러 KeyEntry로 들어오는 패턴(Android에서 동일 원문이 여러
+  // <string name>에 쓰이는 경우 등)을 한 번에 처리하기 위해 keyName 단위로 group한다. 이렇게 하면
+  // setMetadata의 (tag, 'context')/(tag, 'description') 엔트리가 동일 group 내에서 서로를 덮어쓰지
+  // 않고 누적되며, addTags도 (tag, source) 단위로 한 번만 push된다.
+  const entriesByKeyName = new Map<string, KeyEntry[]>()
+  for (const ke of keyEntries) {
+    const arr = entriesByKeyName.get(ke.key)
+    if (arr) arr.push(ke)
+    else entriesByKeyName.set(ke.key, [ke])
+  }
+
+  for (const [entryKey, entries] of entriesByKeyName) {
     const listedKey = listedKeyMap[entryKey]
 
     if (listedKey != null) {
-      const needsTagAdd = !hasTag(listedKey.tags, tag, source)
-      const needsContextUpdate = !metadataContainsContext(listedKey.metadata, tag, keyEntry.context)
-      const needsDescriptionUpdate = !metadataContainsDescription(listedKey.metadata, tag, keyEntry.comments)
+      let baseMetadata: L10nKeyMetadata[] = listedKey.metadata
+      const metaUpdates: L10nKeyMetadata[] = []
 
-      if (needsTagAdd || needsContextUpdate || needsDescriptionUpdate) {
+      for (const ke of entries) {
+        const contextMeta = buildContextMetadata(baseMetadata, tag, ke.context)
+        if (contextMeta) {
+          metaUpdates.push(contextMeta)
+          baseMetadata = mergeMetadata(baseMetadata, [contextMeta])
+        }
+        const descMeta = buildDescriptionMetadata(baseMetadata, tag, ke.comments)
+        if (descMeta) {
+          metaUpdates.push(descMeta)
+          baseMetadata = mergeMetadata(baseMetadata, [descMeta])
+        }
+      }
+
+      // references는 group의 모든 entry refs를 합산해 매 sync 단위로 replace한다.
+      // 이전 sync의 references는 base로 누적시키지 않는다(file:line이 stale일 수 있음).
+      const mergedRefs = mergeReferences(entries.flatMap(e => e.references))
+      const refMeta = buildReferencesMetadata(tag, mergedRefs)
+      const existingRefEntry = listedKey.metadata.find(m => m.tag === tag && m.metaKey === 'references')
+      const refsChanged = refMeta != null
+        && (existingRefEntry == null || existingRefEntry.metaValue !== refMeta.metaValue)
+
+      const needsTagAdd = !hasTag(listedKey.tags, tag, source)
+
+      if (needsTagAdd || metaUpdates.length > 0 || refsChanged) {
         let updating = updatingKeyMap[entryKey]
         if (!updating) {
           updating = { keyId: listedKey.id }
@@ -233,33 +277,34 @@ export function buildKeyChanges(
         if (needsTagAdd) {
           pushAddTag(updating, { tag, source })
         }
-        if (needsContextUpdate) {
-          const contextMeta = buildContextMetadata(listedKey.metadata, tag, keyEntry.context)
-          if (contextMeta) pushSetMetadata(updating, contextMeta)
+        for (const u of metaUpdates) {
+          pushSetMetadata(updating, u)
         }
-        if (needsDescriptionUpdate) {
-          const descMeta = buildDescriptionMetadata(tag, keyEntry.comments)
-          if (descMeta) pushSetMetadata(updating, descMeta)
+        if (refsChanged && refMeta) {
+          pushSetMetadata(updating, refMeta)
         }
-      }
-      // references는 항상 갱신
-      const refMeta = buildReferencesMetadata(tag, keyEntry.references)
-      if (refMeta) {
-        let updating = updatingKeyMap[entryKey]
-        if (!updating) {
-          updating = { keyId: listedKey.id }
-          updatingKeyMap[entryKey] = updating
-        }
-        pushSetMetadata(updating, refMeta)
       }
     } else {
-      // 새 키 생성
+      // 새 키 — group의 모든 entry 데이터를 한 번에 모은다.
       const metadata: L10nKeyMetadata[] = []
-      const contextMeta = buildContextMetadata([], tag, keyEntry.context)
-      if (contextMeta) metadata.push(contextMeta)
-      const descMeta = buildDescriptionMetadata(tag, keyEntry.comments)
-      if (descMeta) metadata.push(descMeta)
-      const refMeta = buildReferencesMetadata(tag, keyEntry.references)
+
+      for (const ke of entries) {
+        const contextMeta = buildContextMetadata(metadata, tag, ke.context)
+        if (contextMeta) {
+          const idx = metadata.findIndex(m => m.tag === contextMeta.tag && m.metaKey === contextMeta.metaKey)
+          if (idx >= 0) metadata[idx] = contextMeta
+          else metadata.push(contextMeta)
+        }
+        const descMeta = buildDescriptionMetadata(metadata, tag, ke.comments)
+        if (descMeta) {
+          const idx = metadata.findIndex(m => m.tag === descMeta.tag && m.metaKey === descMeta.metaKey)
+          if (idx >= 0) metadata[idx] = descMeta
+          else metadata.push(descMeta)
+        }
+      }
+
+      const mergedRefs = mergeReferences(entries.flatMap(e => e.references))
+      const refMeta = buildReferencesMetadata(tag, mergedRefs)
       if (refMeta) metadata.push(refMeta)
 
       if (globalMetadata) {
@@ -278,7 +323,7 @@ export function buildKeyChanges(
 
       creatingKeyMap[entryKey] = {
         keyName: entryKey,
-        isPlural: keyEntry.isPlural,
+        isPlural: entries[0].isPlural,
         tags,
         metadata: metadata.length > 0 ? metadata : undefined,
       }

--- a/packages/syncer-l10n-storage/src/metadata.ts
+++ b/packages/syncer-l10n-storage/src/metadata.ts
@@ -48,10 +48,18 @@ export function metadataContainsDescription(metadata: L10nKeyMetadata[], tag: st
   return comments.every(c => !c || existing.has(c))
 }
 
-export function buildDescriptionMetadata(tag: string, comments: string[]): L10nKeyMetadata | null {
+// existingMetadata에 누락된 comments만 더해서 누적된 description 메타를 만든다.
+// 같은 keyName이 여러 KeyEntry(서로 다른 context)로 들어올 때, 마지막 entry의 comments만 살아남는 회귀를 막기 위함.
+export function buildDescriptionMetadata(existingMetadata: L10nKeyMetadata[], tag: string, comments: string[]): L10nKeyMetadata | null {
   const filtered = comments.filter(Boolean)
   if (filtered.length === 0) return null
-  return { tag, metaKey: 'description', metaValue: filtered.join('\n') }
+  const existing = getDescriptionFromMetadata(existingMetadata, tag)
+  const merged = [...existing]
+  for (const c of filtered) {
+    if (!merged.includes(c)) merged.push(c)
+  }
+  if (merged.length === existing.length) return null
+  return { tag, metaKey: 'description', metaValue: merged.join('\n') }
 }
 
 // --- References ---


### PR DESCRIPTION
## Summary

같은 `keyName`이 여러 `context`로 들어오는 패턴(Android에서 동일 원문이 여러 `<string name>`에 쓰이는 경우 등)에서 Pass 2가 의도된 누적 동작을 완성하지 못해 마지막 entry의 context만 살아남던 미완성을 보완합니다.

- **원래 의도**: `pushSetMetadata`는 `(tag, metaKey)` 단위 idx-replace로 단일 엔트리에 모으는 구조였고, `buildContextMetadata`는 `existingMetadata` 기반으로 새 context를 append하는 시그니처 — 누적이 명확한 디자인이었음
- **실제 동작**: keyEntries iteration이 in-flight `setMetadata` 상태를 base에 반영하지 않고 매번 frozen `listedKey.metadata`만 base로 호출. 두 번째 iter가 첫 번째 iter의 context를 덮어쓰며 손실
- **부가 미스**: `needsTagAdd`가 `listedKey.tags`만 보고 in-flight `addTags`를 안 봐서 `(tag, source)` 중복 push (서버는 `ON CONFLICT DO NOTHING`으로 dedup하므로 sync 실패는 없었으나 페이로드 낭비)

## Fix

- `keyEntries`를 `keyName` 단위로 group해서 한 그룹을 한 번에 처리. 그룹 내에서 `baseMetadata`를 점진적으로 누적시켜 `buildContextMetadata` / `buildDescriptionMetadata` 호출
- `addTags`는 그룹 단위로 `(tag, source)` 최대 1회 push
- `buildDescriptionMetadata` 시그니처를 `(existingMetadata, tag, comments)`로 변경 — 기존 description에 누락된 comment만 누적
- References는 그룹의 모든 entry refs를 `mergeReferences`로 dedup해서 한 번에 `setMetadata`. 기존 `metaValue`와 동일하면 update 자체를 skip(불필요 update 방지)
- 새 키 생성 분기도 동일한 group 누적 로직 적용

## Test plan

- [x] `buildKeyChanges` 단위 테스트 6개 추가 (context 누적, addTags dedup, description merge, references 합산, references unchanged skip, 새 키 누적)
- [x] 전체 워크스페이스 테스트 통과 (292 pass / 0 fail)
- [x] build / lint 통과
- [ ] CI 통과 확인

## Reference

- 검토 배경: tpcint/likey-android#1687 의 Codex 리뷰 검토 중 발견
- 1.3.3 회귀가 아니라 최초 도입 시점(#276)부터 있던 미완성. 1.3.3 (#341)에서 `hasTagName` → `hasTag` 변경으로 addTags 중복 가능성이 가시화됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)