### PR TITLE
fix(syncer-l10n-storage): scope PR-source claim to actual context additions

### DIFF
--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -53,10 +53,11 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(creatingKeys[0].tags, [{ tag: 'backend', source: 'main' }])
   })
 
-  it('should add tag when key has the tag with another source (per-source tagging)', () => {
-    // A PR referencing a key that main already owns must still claim its own
-    // (tag, source) ownership; otherwise the source filter cannot return the key
-    // back to this PR's apply step.
+  it('should NOT claim (tag, source) for non-authoritative source when no new context is added', () => {
+    // A PR-scoped sync (non-authoritative source) extracts the entire local file, so every
+    // key flows through Pass 2 even if the PR did not touch it. To avoid PR-N claiming every
+    // key in the project — which previously caused ~2000-key "upload" notifications on
+    // PRs that only deleted a handful of strings — claim must require an actual new context.
     const keyEntries = [createKeyEntry('existing.key')]
     const listedKeyMap = {
       'existing.key': createL10nKey('existing.key', {
@@ -65,12 +66,61 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-123', 'backend', keyEntries, {}, listedKeyMap,
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('should NOT claim (tag, source) for non-authoritative source when only references change', () => {
+    // References (file:line) drift with PR diffs but are not exposed by the source filter,
+    // so PR-N must not claim ownership just because file locations changed.
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), references: [{ file: 'app/values/strings.xml', loc: '99' }] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [
+          { tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) },
+          { tag: 'android-likey', metaKey: 'references', metaValue: JSON.stringify([{ file: 'app/values/strings.xml', loc: '12' }]) },
+        ],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'PR-1692', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    // refs are updated, but no (tag, source) claim
     assert.equal(updatingKeys.length, 1)
-    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'backend', source: 'PR-123' }])
+    assert.equal(updatingKeys[0].addTags, undefined)
+    const refsMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'references')
+    assert.ok(refsMeta != null)
+  })
+
+  it('should NOT claim (tag, source) for non-authoritative source when only description changes', () => {
+    // Description metadata is not exposed by the source filter either, so a description-only
+    // change does not warrant a PR-N claim.
+    const keyEntries: KeyEntry[] = [
+      { ...createKeyEntry('취소', { context: 'a' }), comments: ['New developer note'] },
+    ]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'PR-42', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    assert.equal(updatingKeys[0].addTags, undefined)
+    const descMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'description')
+    assert.ok(descMeta != null)
   })
 
   it('should not add tag when key already has the tag with the same source', () => {
@@ -82,7 +132,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-123', 'backend', keyEntries, {}, listedKeyMap,
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -122,7 +172,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-99', 'android-likey', keyEntries, {}, listedKeyMap,
+      'PR-99', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -317,7 +367,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-77', 'android-likey', keyEntries, {}, listedKeyMap,
+      'PR-77', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
     )
 
     assert.equal(updatingKeys.length, 1)

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -244,12 +244,14 @@ export function buildKeyChanges(
     if (listedKey != null) {
       let baseMetadata: L10nKeyMetadata[] = listedKey.metadata
       const metaUpdates: L10nKeyMetadata[] = []
+      let contextAdded = false
 
       for (const ke of entries) {
         const contextMeta = buildContextMetadata(baseMetadata, tag, ke.context)
         if (contextMeta) {
           metaUpdates.push(contextMeta)
           baseMetadata = mergeMetadata(baseMetadata, [contextMeta])
+          contextAdded = true
         }
         const descMeta = buildDescriptionMetadata(baseMetadata, tag, ke.comments)
         if (descMeta) {
@@ -268,7 +270,14 @@ export function buildKeyChanges(
       const refsChanged = (mergedRefs.length > 0 || existingRefEntry != null)
         && (existingRefEntry == null || existingRefEntry.metaValue !== mergedRefsValue)
 
-      const needsTagAdd = !hasTag(listedKey.tags, tag, source)
+      // 비권위 source(PR-N 등)는 키에 새 context를 추가하는 경우에만 (tag, source)를 claim한다.
+      // 비권위 source가 단순히 keyEntries에 키를 포함시킨 것만으로 모든 키에 PR-N 태그를 붙이면,
+      // PR scope sync마다 모든 키가 update 대상으로 잡혀 storage에 폭주 알림이 발생한다.
+      // source filter는 contexts/translations만 노출하므로, description/references 변경은
+      // PR apply 단계에 propagate할 필요가 없어 claim 대상에서 제외한다. 권위 source(예: main)는
+      // tag ownership 관리 책임이 있으므로 기존대로 자기 (tag, source) 태그가 없으면 항상 claim.
+      const hasOwnSourceTag = hasTag(listedKey.tags, tag, source)
+      const needsTagAdd = !hasOwnSourceTag && (isAuthoritativeSource || contextAdded)
 
       if (needsTagAdd || metaUpdates.length > 0 || refsChanged) {
         let updating = updatingKeyMap[entryKey]


### PR DESCRIPTION
## Summary

- PR scope sync(`source=PR-N`)이 모든 키에 `(tag, source)` 태그를 무조건 claim하면서 PR마다 ~2000개 키 "업로드" 알림이 폭주하던 회귀를 수정합니다.
- 비권위 source는 **새 context가 실제로 추가되는 경우에만** claim하도록 좁힙니다. references/description 변경은 source filter에 노출되지 않으므로 claim 사유에서 제외합니다.
- #341의 원래 회귀 fix(새 Android `name`이 기존 번역 재사용 시 PR apply가 키를 잡아야 함)는 그대로 보존됩니다 — 그 경로는 새 context를 추가하므로 claim이 여전히 트리거됩니다.

## 배경

PR #341에서 Pass 2의 `needsTagAdd` 판정이 `hasTagName(tags, tag)` → `hasTag(tags, tag, source)`로 변경되면서, PR scope sync 시 keyEntries에 포함된 모든 키가 `updatingKeys`로 들어가게 되었습니다. `uploadToL10nStorage`가 500개 chunk로 `updateKeys()`를 호출하므로 tpc-agent는 chunk 단위로 "X개 키 업로드" 알림을 보냅니다 — 안드로이드 PR-1692 사례에서 500/500/500/432 (≈1932) 알림 4건이 정확히 이 패턴이었습니다.

## Test plan

- [x] `should NOT claim (tag, source) for non-authoritative source when no new context is added` (PR-1692 회귀 방지)
- [x] `should NOT claim (tag, source) for non-authoritative source when only references change`
- [x] `should NOT claim (tag, source) for non-authoritative source when only description changes`
- [x] `should add (tag, source) when a new context is added to an existing keyName` (#341 회귀 보존, `isAuthoritativeSource: false` 명시)
- [x] 권위 source(`main`) 경로는 기존 테스트들로 회귀 없음 확인
- [x] `npm run lint`, `tsc -b` 통과
- [x] `syncer-l10n-storage` 전체 테스트 40/40 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)