### PR TITLE
ci: skip pkg-pr-new on dependabot PRs

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   publish:
     name: Publish preview
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: pkg-pr-new-pr${{ github.event.number }}


### PR DESCRIPTION
## Summary
- Skip `pkg-pr-new` preview publish job when the PR is opened by `dependabot[bot]`
- Dep bumps don't benefit from preview installs, and build/test workflows already catch regressions

## Test plan
- [ ] Confirm next dependabot PR shows `Publish preview` as Skipped
- [ ] Confirm regular PRs still publish preview as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)