### PR TITLE
perf(syncer-l10n-storage): raise list keys page size from 500 to 5000

### DIFF
--- a/packages/syncer-l10n-storage/src/api-client.ts
+++ b/packages/syncer-l10n-storage/src/api-client.ts
@@ -45,7 +45,7 @@ export class L10nStorageApiClient {
     let previousCursor: string | undefined
     do {
       log.info('l10n-storage-api', `listing keys${cursor ? ` (cursor: ${cursor})` : ''}`)
-      const params = new URLSearchParams({ limit: '500' })
+      const params = new URLSearchParams({ limit: '5000' })
       if (cursor) params.set('cursor', cursor)
       const response = await this.request<ListKeysToServeResponse>(
         'GET',
@@ -76,7 +76,7 @@ export class L10nStorageApiClient {
         'l10n-storage-api',
         `listing keys (tag: ${tag}${source ? `, source: ${source}` : ''}${cursor ? `, cursor: ${cursor}` : ''})`,
       )
-      const params = new URLSearchParams({ limit: '500' })
+      const params = new URLSearchParams({ limit: '5000' })
       if (cursor) params.set('cursor', cursor)
       if (source) params.set('source', source)
       const response = await this.request<ListKeysToServeResponse>(


### PR DESCRIPTION
## Summary
- L10n Storage API의 `keys-to-serve` 페이지 limit을 500 → 5000으로 상향
- 500은 Lokalise API 상한이었고, l10n-storage(tpc-agent)는 `.max(5000)`까지 허용 (`src/api/l10n.routes.ts:219, 243`)
- 키가 많은 프로젝트에서 페이지네이션 호출 횟수 약 1/10로 감소

## Test plan
- [x] `npm run build`, `npm run lint` 통과
- [ ] 실제 동기화로 호출 횟수 감소 및 모든 키 정상 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)