### PR TITLE
fix(syncer-l10n-storage): claim and clean up PR-source tags in context-less domains

### DIFF
--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -302,4 +302,71 @@ describe('syncTransToL10nStorage (e2e)', () => {
 
     assert.equal(localTrans.en[0].flag, null)
   })
+
+  it('PR source claims an existing key first introduced under this tag, no context (수정 A)', async () => {
+    // 다른 repo(web)가 만든 키를 web4가 PR에서 처음 사용. context 없는 도메인이라 contextAdded는
+    // 영영 false지만, web4가 이 키를 처음 다루므로 (web4, PR-1)을 claim해야 한다.
+    await seedKeys(projectId!, [{
+      keyName: '취소',
+      tags: [{ tag: 'web', source: 'main' }],
+    }])
+
+    // configSource='main', options.source='PR-1' → 비권위 source
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web4', [key('취소')], {}, false, { source: 'PR-1' },
+    )
+
+    const served = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'PR-1')
+    assert.deepEqual(served.map(k => k.keyName), ['취소'])
+
+    // 기존 (web, main) 태그는 보존되고 (web4, PR-1)이 추가됨
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    const pairs = k.tags.map(t => ({ tag: t.tag, source: t.source }))
+    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'main'))
+    assert.ok(pairs.some(p => p.tag === 'web4' && p.source === 'PR-1'))
+  })
+
+  it('PR source does NOT claim a key this tag already owns (수정 A 음성, no flood)', async () => {
+    // "불러오는 중..." 유형: main이 이미 (web4, main)으로 소유. PR이 추출에 포함했다고 claim하면 안 됨.
+    await seedKeys(projectId!, [{
+      keyName: '불러오는 중...',
+      tags: [{ tag: 'web4', source: 'main' }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web4', [key('불러오는 중...')], {}, false, { source: 'PR-1' },
+    )
+
+    const served = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'PR-1')
+    assert.deepEqual(served.map(k => k.keyName), [])
+  })
+
+  it('PR source removes an orphan (tag, source) when the key disappears, preserving main scope (수정 B)', async () => {
+    // 과거 PR-1이 claim했다가 코드에서 사라진 키. PR-1 sync(추출 0건)에서 (web4, PR-1) orphan을
+    // 제거해야 _remoteCount(PR-1)이 0이 되어 체크런이 풀린다. (web4, main)과 공유 context는 불변.
+    await seedKeys(projectId!, [{
+      keyName: 'orphan.key',
+      tags: [{ tag: 'web4', source: 'PR-1' }, { tag: 'web4', source: 'main' }],
+      metadata: [{ tag: 'web4', metaKey: 'context', metaValue: JSON.stringify(['shared']) }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    // PR이 더 이상 이 키를 추출하지 않음
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'web4', [], {}, false, { source: 'PR-1' },
+    )
+
+    const prScope = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'PR-1')
+    assert.deepEqual(prScope.map(k => k.keyName), [], 'orphan PR-1 claim removed')
+
+    const mainScope = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'main')
+    assert.ok(mainScope.map(k => k.keyName).includes('orphan.key'), 'main scope preserved')
+
+    // 키 자체는 삭제되지 않고 공유 context도 유지
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    const ctxMeta = k.metadata.find(m => m.tag === 'web4' && m.metaKey === 'context')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['shared'])
+  })
 })

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -510,11 +510,12 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(JSON.parse(contextMeta.metaValue), ['a:one', 'b:two'])
   })
 
-  it('Pass 1: should be skipped for non-authoritative source (add-only)', () => {
-    // A PR source claimed the key on a previous sync. On a later PR sync where the PR's
-    // local no longer references one of the contexts, Pass 1 must NOT strip it: contexts
-    // are shared across sources via tag-level metadata, so the PR could otherwise remove
-    // a context that 'main' still uses. Only the authoritative source may clean up.
+  it('Pass 1: non-authoritative source drops its own orphan (tag, source) but never touches shared context', () => {
+    // A PR source claimed the key on a previous sync, but the PR's local no longer extracts it.
+    // The PR-N tag is now an orphan: it keeps _remoteCount/source filter surfacing the key,
+    // freezing the check run on "Translations are not applied". So the PR's own (tag, source)
+    // must be removed. Crucially, the shared context metadata (["main_ctx", "pr_ctx"]) must NOT
+    // be touched — contexts are shared across sources per tag, and 'main' still uses them.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
       'shared.key': createL10nKey('shared.key', {
@@ -531,7 +532,136 @@ describe('buildKeyChanges', () => {
       'PR-7', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
     )
 
+    assert.equal(updatingKeys.length, 1)
+    assert.equal(updatingKeys[0].keyId, 'key-1')
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend', source: 'PR-7' }])
+    // shared context metadata untouched
+    assert.equal(updatingKeys[0].setMetadata, undefined)
+    assert.equal(updatingKeys[0].addTags, undefined)
+  })
+
+  it('non-authoritative source claims an existing key first introduced by this tag (no context, e.g. web4)', () => {
+    // Regression (#346): a context-less domain like likey-web-4 vue-i18n never produces a new
+    // context, so the old `contextAdded`-only rule meant a PR could never claim an existing key.
+    // When the key already exists on the server under another tag (created by a different repo)
+    // and this tag has never owned it, the PR-N source must claim (tag, source) so the source
+    // filter / _remoteCount surface it for compile-from-source.
+    const keyEntries = [createKeyEntry('취소')] // context null
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'web', source: 'main' }], // owned by 'web', never by 'web4'
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'web4', source: 'PR-1' }])
+  })
+
+  it('non-authoritative source does NOT claim an existing key this tag already owns (no flood)', () => {
+    // "불러오는 중..." 유형: main이 이미 (web4, main)으로 소유하고 번역까지 끝난 키. PR이 단순히
+    // 추출에 포함시켰다고 claim하면 PR마다 모든 web4 키가 잡혀 #346 폭주가 재현된다. 자기 태그가
+    // 이미 있으므로 claim하지 않아야 한다.
+    const keyEntries = [createKeyEntry('불러오는 중...')] // context null
+    const listedKeyMap = {
+      '불러오는 중...': createL10nKey('불러오는 중...', {
+        tags: [{ tag: 'web4', source: 'main' }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(creatingKeys.length, 0)
     assert.equal(updatingKeys.length, 0)
+  })
+
+  it('non-authoritative source still claims when a new context is added (context-ful domain, e.g. Android)', () => {
+    // Regression guard for the original #346 fix: in a context-ful domain, adding a brand-new
+    // context to an existing key must still claim (tag, source) via the contextAdded path,
+    // independent of the new hasAnyOwnTag path.
+    const keyEntries = [createKeyEntry('취소', { context: 'b' })]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a']) }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-9', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'android-likey', source: 'PR-9' }])
+    const contextMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'context')
+    assert.ok(contextMeta != null)
+    assert.deepEqual(JSON.parse(contextMeta.metaValue), ['a', 'b'])
+  })
+
+  it('Pass 1 (non-authoritative): does NOT remove tag for a key still present in local extraction', () => {
+    // The key carries its own (tag, source) claim and is still extracted locally → it is a live
+    // claim, not an orphan, so Pass 1 must leave it alone (Pass 2 keeps the claim).
+    const keyEntries = [createKeyEntry('살아있는키')]
+    const listedKeyMap = {
+      살아있는키: createL10nKey('살아있는키', {
+        id: 'live-1',
+        tags: [{ tag: 'web4', source: 'PR-1' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    const removeTagUpdates = updatingKeys.filter(u => u.removeTags != null)
+    assert.equal(removeTagUpdates.length, 0)
+  })
+
+  it('Pass 1 (non-authoritative): leaves the key itself (and other-source tags) intact when dropping an orphan', () => {
+    // Removing the orphan PR-1 tag must not remove the (web4, main) tag nor delete the key.
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      지워진키: createL10nKey('지워진키', {
+        id: 'orphan-1',
+        tags: [{ tag: 'web4', source: 'PR-1' }, { tag: 'web4', source: 'main' }],
+        metadata: [{ tag: 'web4', metaKey: 'context', metaValue: JSON.stringify(['shared']) }],
+      }),
+    }
+
+    const { creatingKeys, updatingKeys } = buildKeyChanges(
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+    )
+
+    assert.equal(creatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'web4', source: 'PR-1' }])
+    // (web4, main) is not removed and shared context is untouched
+    assert.equal(updatingKeys[0].setMetadata, undefined)
+  })
+
+  it('Pass 1 (authoritative): unaffected by 수정 A/B — claims own tag for a key it does not yet own', () => {
+    // main is authoritative; even with the new hasAnyOwnTag path, authoritative short-circuits
+    // first, so a key it doesn't own yet is still claimed exactly as before.
+    const keyEntries = [createKeyEntry('취소')] // context null
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'web', source: 'main' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'web4', keyEntries, {}, listedKeyMap, // isAuthoritativeSource defaults to true
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'web4', source: 'main' }])
   })
 })
 

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -96,6 +96,10 @@ function hasTag(tags: L10nKeyTag[], tag: string, source: string): boolean {
   return tags.some(t => t.tag === tag && t.source === source)
 }
 
+function hasTagAnySource(tags: L10nKeyTag[], tag: string): boolean {
+  return tags.some(t => t.tag === tag)
+}
+
 function hasTranslation(key: L10nKeyToServe, locale: string): boolean {
   return key.translations.some(t => t.locale === locale)
 }
@@ -193,10 +197,25 @@ export function buildKeyChanges(
   const globalMetadata = options?.globalMetadata
   const tagMetadata = options?.tagMetadata
 
-  // Pass 1: 서버에 있고 우리 source 태그가 있는 키 → 로컬에 없는 context 제거.
-  // Context metadata는 (tag) 단위로 모든 source가 공유하므로, 권위가 없는 source(예: PR-N)가
-  // cleanup을 수행하면 다른 source의 context를 의도치 않게 지울 수 있다.
-  // 따라서 권위 source(config의 source)일 때만 Pass 1을 활성화한다. 임시 source는 add-only.
+  // 로컬 keyEntries를 keyName 단위로 group한다. 같은 keyName이 서로 다른 context로 여러 KeyEntry로
+  // 들어오는 패턴(Android에서 동일 원문이 여러 <string name>에 쓰이는 경우 등)을 한 번에 처리하기
+  // 위함이다. 이렇게 하면 setMetadata의 (tag, 'context')/(tag, 'description') 엔트리가 동일 group
+  // 내에서 서로를 덮어쓰지 않고 누적되며, addTags도 (tag, source) 단위로 한 번만 push된다.
+  // Pass 1의 orphan 판정(로컬 추출에 없는 키)에도 사용하므로 두 pass보다 먼저 만든다.
+  const entriesByKeyName = new Map<string, KeyEntry[]>()
+  for (const ke of keyEntries) {
+    const arr = entriesByKeyName.get(ke.key)
+    if (arr) arr.push(ke)
+    else entriesByKeyName.set(ke.key, [ke])
+  }
+
+  // Pass 1: 서버에 있고 우리 source 태그가 있는 키의 정리.
+  // - 권위 source(config의 source): 로컬에 없는 context를 제거하고, context가 모두 사라지면 태그도 제거.
+  //   Context metadata는 (tag) 단위로 모든 source가 공유하므로 이 cleanup은 권위 source만 수행한다.
+  // - 비권위 source(예: PR-N): 공유 context는 절대 건드리지 않되, 로컬 추출에서 완전히 사라진 키의
+  //   자기 (tag, source) 태그만 제거한다. 이렇게 하면 과거 PR가 claim했다가 코드에서 삭제된 orphan이
+  //   _remoteCount/source filter에 영구히 남아 체크런이 고착되는 회귀를 막는다. 자기 태그 제거는 다른
+  //   source에 영향을 주지 않아 안전하다.
   if (isAuthoritativeSource) {
     for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
       if (!hasTag(listedKey.tags, tag, source)) continue
@@ -224,20 +243,23 @@ export function buildKeyChanges(
         }
       }
     }
+  } else {
+    for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
+      if (!hasTag(listedKey.tags, tag, source)) continue
+      // 로컬 추출에 아직 있으면 Pass 2에서 처리(claim 유지). 사라진 키만 orphan으로 본다.
+      if (entriesByKeyName.has(keyName)) continue
+
+      let updating = updatingKeyMap[keyName]
+      if (!updating) {
+        updating = { keyId: listedKey.id }
+        updatingKeyMap[keyName] = updating
+      }
+      // 자기 (tag, source) 태그만 제거. 공유 context/description metadata는 건드리지 않는다.
+      pushRemoveTag(updating, { tag, source })
+    }
   }
 
   // Pass 2: 로컬 keyEntries → 새 키 생성 또는 기존 키 업데이트.
-  // 같은 keyName이 서로 다른 context로 여러 KeyEntry로 들어오는 패턴(Android에서 동일 원문이 여러
-  // <string name>에 쓰이는 경우 등)을 한 번에 처리하기 위해 keyName 단위로 group한다. 이렇게 하면
-  // setMetadata의 (tag, 'context')/(tag, 'description') 엔트리가 동일 group 내에서 서로를 덮어쓰지
-  // 않고 누적되며, addTags도 (tag, source) 단위로 한 번만 push된다.
-  const entriesByKeyName = new Map<string, KeyEntry[]>()
-  for (const ke of keyEntries) {
-    const arr = entriesByKeyName.get(ke.key)
-    if (arr) arr.push(ke)
-    else entriesByKeyName.set(ke.key, [ke])
-  }
-
   for (const [entryKey, entries] of entriesByKeyName) {
     const listedKey = listedKeyMap[entryKey]
 
@@ -270,14 +292,20 @@ export function buildKeyChanges(
       const refsChanged = (mergedRefs.length > 0 || existingRefEntry != null)
         && (existingRefEntry == null || existingRefEntry.metaValue !== mergedRefsValue)
 
-      // 비권위 source(PR-N 등)는 키에 새 context를 추가하는 경우에만 (tag, source)를 claim한다.
-      // 비권위 source가 단순히 keyEntries에 키를 포함시킨 것만으로 모든 키에 PR-N 태그를 붙이면,
-      // PR scope sync마다 모든 키가 update 대상으로 잡혀 storage에 폭주 알림이 발생한다.
-      // source filter는 contexts/translations만 노출하므로, description/references 변경은
-      // PR apply 단계에 propagate할 필요가 없어 claim 대상에서 제외한다. 권위 source(예: main)는
-      // tag ownership 관리 책임이 있으므로 기존대로 자기 (tag, source) 태그가 없으면 항상 claim.
+      // 비권위 source(PR-N 등)의 claim 조건. 단순히 keyEntries에 키를 포함시킨 것만으로 모든 키에
+      // PR-N 태그를 붙이면, PR scope sync마다 모든 키가 update 대상으로 잡혀 storage에 폭주 알림이
+      // 발생한다(#346). 그래서 비권위 source는 다음 중 하나일 때만 claim한다:
+      //   - contextAdded: 키에 새 context를 추가 (Android에서 동일 원문을 새 <string name>에 쓰는 경우).
+      //   - !hasAnyOwnTag: 이 태그가 이 키를 처음 다룸. 다른 repo가 만든 기존 키를 이 도메인이 처음
+      //     사용하기 시작하는 마이그레이션 케이스. context가 없는 도메인(예: web4 vue-i18n)은 contextAdded가
+      //     영영 false라, 이 신호가 없으면 기존 키를 절대 claim하지 못한다(회귀). 폭주는 발생하지 않는데,
+      //     이 도메인이 이미 다루던 키는 (tag, main 등) 자기 태그를 가져 hasAnyOwnTag가 true이기 때문이다.
+      // description/references 변경은 source filter에 노출되지 않아 PR apply에 propagate할 필요가 없으므로
+      // claim 대상에서 제외한다. 권위 source(예: main)는 tag ownership 관리 책임이 있어 자기 (tag, source)가
+      // 없으면 항상 claim(isAuthoritativeSource 단락평가로 동작 불변).
       const hasOwnSourceTag = hasTag(listedKey.tags, tag, source)
-      const needsTagAdd = !hasOwnSourceTag && (isAuthoritativeSource || contextAdded)
+      const hasAnyOwnTag = hasTagAnySource(listedKey.tags, tag)
+      const needsTagAdd = !hasOwnSourceTag && (isAuthoritativeSource || contextAdded || !hasAnyOwnTag)
 
       if (needsTagAdd || metaUpdates.length > 0 || refsChanged) {
         let updating = updatingKeyMap[entryKey]


### PR DESCRIPTION
## Summary

#346이 비권위(PR-N) source의 태그 claim을 "새 context가 추가된 키"로 좁혔는데, context가 없는 도메인(likey-web-4 vue-i18n — `translate-context`를 쓰지 않아 context가 항상 null)에서는 PR이 (1) 처음 도입하는 기존 키를 claim하지도, (2) 이전 sync가 남긴 claim을 정리하지도 못했습니다. 그 결과 orphan `(tag, PR-N)`이 남아 `_remoteCount > 0`을 유지하고, 체크런이 "Translations are not applied"로 고착됩니다.

- **수정 A**: `hasTagAnySource`로 "이 태그가 이 키를 처음 다루는" 경우에도 `(tag, source)`를 claim (기존 `contextAdded` 경로에 추가). 이미 자기 태그를 가진 키는 그대로 스킵하여 #346 폭주 방지 의도 보존.
- **수정 B**: 비권위 Pass 1 분기를 추가해 **로컬 추출에서 사라진 키의 자기 `(tag, source)` 태그만** 제거. 공유 context metadata(권위 source 소유)는 일절 건드리지 않음.

## Test plan

- [x] 유닛 테스트 (`l10n-storage.test.ts`) — 46개 통과. 기존 #346 테스트 불변, 신규: claim 양성/음성, contextAdded 회귀 가드, orphan 제거/live 보존, authoritative 불변
- [x] e2e 테스트 (`l10n-storage.e2e.test.ts`) — 로컬 tpc-agent 백엔드에서 22개 통과 (멀티태그 first-use / 자기태그 비claim / orphan cleanup 신규 3개 포함)
- [x] `tsc -b` build / `eslint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)