### PR TITLE
fix: sync package-lock.json tsx version to 4.22.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import-newlines": "^2.0.0",
         "eslint-plugin-import-x": "^4.16.2",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4"
       },
@@ -3145,9 +3145,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 문제

`main`의 publish 워크플로우에서 `npm ci`가 실패하고 있었습니다 ([run 26446838398](https://github.com/tpcint/l10n-tools/actions/runs/26446838398)):

```
npm error Invalid: lock file's tsx@4.22.0 does not satisfy tsx@4.22.3
```

## 원인

| 커밋 | package.json | lock |
|------|-------------|------|
| `3acb61c` (tsx bump #357) | `^4.22.3` | `4.22.3` ✅ |
| `83eae1d` (release #359) | `^4.22.3` | `4.22.0` ❌ |

PR #357이 `package.json`/`package-lock.json`을 둘 다 4.22.3으로 올렸지만, 직후 머지된 release-please 커밋 #359가 stale한 lock 스냅샷으로 **tsx 항목만 4.22.0으로 되돌려** package.json과 어긋났습니다.

## 수정

`npm install --package-lock-only`로 lock을 `package.json`과 다시 동기화 (tsx → 4.22.3). 다른 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)