### PR TITLE
feat(syncer-l10n-storage): tag-filtered fetch and (tag,*) unclaim under single-source model

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,8 @@ name: E2E Tests
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    # `edited`를 포함해서 PR body의 `tpc-agent-tag:` 마커 추가/변경 시 재실행되도록 한다.
+    types: [opened, synchronize, edited]
 
 jobs:
   changes:
@@ -13,6 +14,7 @@ jobs:
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     outputs:
       should_run: ${{ steps.filter.outputs.syncer_l10n_storage }}
+      backend_image: ${{ steps.backend.outputs.image }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -25,6 +27,26 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/e2e.yml'
+
+      - name: Resolve backend image from PR body
+        # PR description에 `tpc-agent-tag: <tag>` 한 줄이 있으면 그 태그의 tpc-agent PR 빌드 이미지로
+        # e2e를 돌린다. 마커가 없으면 기본 BACKEND_IMAGE secret으로 fallback.
+        id: backend
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          TAG=$(printf '%s\n' "$PR_BODY" \
+            | grep -iE '^[[:space:]]*tpc-agent-tag:[[:space:]]*[A-Za-z0-9._-]+[[:space:]]*$' \
+            | head -1 \
+            | sed -E 's/^[[:space:]]*[^:]+:[[:space:]]*//; s/[[:space:]]*$//')
+          if [ -n "$TAG" ]; then
+            IMAGE="gcr.io/tpc-misc/tpc-misc-tpc-agent:${TAG}"
+            echo "Using tpc-agent image: ${IMAGE}"
+            echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No tpc-agent-tag marker in PR body; using default backend image"
+            echo "image=" >> "$GITHUB_OUTPUT"
+          fi
 
   e2e:
     name: E2E Tests
@@ -44,7 +66,8 @@ jobs:
       id-token: write
 
     env:
-      BACKEND_IMAGE: ${{ secrets.BACKEND_IMAGE }}
+      # PR body의 tpc-agent-tag 마커가 있으면 그 PR 빌드 이미지를, 없으면 기본 secret 이미지를 사용한다.
+      BACKEND_IMAGE: ${{ needs.changes.outputs.backend_image || secrets.BACKEND_IMAGE }}
 
     steps:
       - uses: actions/checkout@v6

--- a/packages/syncer-l10n-storage/src/api-types.ts
+++ b/packages/syncer-l10n-storage/src/api-types.ts
@@ -6,8 +6,8 @@ export interface L10nKeyTag {
 /**
  * removeTags 입력. source를 생략하면 그 `(key, tag)`의 모든 source row를 unclaim한다.
  * source를 명시하면 해당 `(tag, source)` 한 줄만 제거한다.
- * 권위 source의 cleanup은 source 생략 형태를 쓰고, 비권위 source(PR scope)의 self-cleanup은
- * 자기 `(tag, source)`만 정리하기 위해 source를 명시한다.
+ * 전체 sync(특정 PR 스코프가 아닌 default sync)의 cleanup은 source 생략 형태를 쓰고, 특정 source
+ * sync(PR scope)의 self-cleanup은 자기 `(tag, source)`만 정리하기 위해 source를 명시한다.
  */
 export interface RemoveTagInput {
   tag: string,

--- a/packages/syncer-l10n-storage/src/api-types.ts
+++ b/packages/syncer-l10n-storage/src/api-types.ts
@@ -3,6 +3,17 @@ export interface L10nKeyTag {
   source: string,
 }
 
+/**
+ * removeTags 입력. source를 생략하면 그 `(key, tag)`의 모든 source row를 unclaim한다.
+ * source를 명시하면 해당 `(tag, source)` 한 줄만 제거한다.
+ * 권위 source의 cleanup은 source 생략 형태를 쓰고, 비권위 source(PR scope)의 self-cleanup은
+ * 자기 `(tag, source)`만 정리하기 위해 source를 명시한다.
+ */
+export interface RemoveTagInput {
+  tag: string,
+  source?: string,
+}
+
 export interface L10nKeyMetadata {
   tag: string | null,
   metaKey: string,
@@ -40,7 +51,7 @@ export interface CreateL10nKeyInput {
 export interface UpdateL10nKeyInput {
   keyId: string,
   addTags?: L10nKeyTag[],
-  removeTags?: L10nKeyTag[],
+  removeTags?: RemoveTagInput[],
   setMetadata?: L10nKeyMetadata[],
   suggestions?: CreateSuggestionInput[],
 }

--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -89,7 +89,10 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.deepEqual(tagPair(bye), [{ tag: 'web', source: 'main' }])
   })
 
-  it('claims (tag, source) when another source already owns the same tag', async () => {
+  it('addTags is silently skipped when another source already owns the (key, tag)', async () => {
+    // PR 1161: (key_id, tag) PK이므로 한 (key, tag)는 한 source만 점유. main이 sync에서 자기
+    // (web, main) claim을 시도해도 server가 ON CONFLICT DO NOTHING으로 silent skip하고 기존 source가
+    // 그대로 유지된다. syncer는 이 동작에 의존해 idempotent하게 addTags를 보낸다.
     await seedKeys(projectId!, [{
       keyName: 'shared.key',
       tags: [{ tag: 'web', source: 'other' }],
@@ -101,13 +104,10 @@ describe('syncTransToL10nStorage (e2e)', () => {
     )
 
     const [k] = await apiClient.listAllKeysToServe(projectId!)
-    // Per-source ownership: 'main' references the key locally so it claims its own
-    // (tag, source) tag alongside the existing one — otherwise the source filter for
-    // 'main' would not include this key.
-    const pairs = k.tags.map(t => ({ tag: t.tag, source: t.source }))
-    assert.equal(pairs.length, 2)
-    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'other'))
-    assert.ok(pairs.some(p => p.tag === 'web' && p.source === 'main'))
+    assert.deepEqual(
+      k.tags.map(t => ({ tag: t.tag, source: t.source })),
+      [{ tag: 'web', source: 'other' }],
+    )
   })
 
   it('downloads server translations into local trans entries', async () => {
@@ -191,22 +191,22 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.equal(k.tags.length, 1, 'tag remains because ctx-A still belongs to main')
   })
 
-  it('removes own-source tag when all contexts are gone', async () => {
+  it('removes the tag and empties context when all contexts are gone from local', async () => {
+    // 전체 sync가 로컬에 없는 마지막 context까지 다 빼고 나면 (tag, *)를 source-omitted로 unclaim한다.
+    // 단일-source 모델이라 "다른 source 보존" 시나리오는 정의상 존재하지 않는다.
     await seedKeys(projectId!, [{
       keyName: 'ctx.gone.key',
-      tags: [{ tag: 'web', source: 'main' }, { tag: 'web', source: 'other' }],
+      tags: [{ tag: 'web', source: 'main' }],
       metadata: [{ tag: 'web', metaKey: 'context', metaValue: JSON.stringify(['ctx-only']) }],
     }])
 
     const config = buildL10nConfig(projectId!, { source: 'main' })
-    // 로컬엔 더 이상 ctx-only가 없음 → main source 태그가 빠져야 함
     await syncTransToL10nStorage(
       config, buildDomainConfig(), 'web', [], {}, false,
     )
 
     const [k] = await apiClient.listAllKeysToServe(projectId!)
-    assert.ok(!k.tags.some(t => t.source === 'main'), 'main source tag removed')
-    assert.ok(k.tags.some(t => t.source === 'other'), 'other source tag preserved')
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
     const ctxMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'context')
     assert.deepEqual(JSON.parse(ctxMeta!.metaValue), [])
   })
@@ -311,7 +311,7 @@ describe('syncTransToL10nStorage (e2e)', () => {
       tags: [{ tag: 'web', source: 'main' }],
     }])
 
-    // configSource='main', options.source='PR-1' → 비권위 source
+    // configSource='main', options.source='PR-1' → 비전체 sync
     const config = buildL10nConfig(projectId!, { source: 'main' })
     await syncTransToL10nStorage(
       config, buildDomainConfig(), 'web4', [key('취소')], {}, false, { source: 'PR-1' },
@@ -343,30 +343,122 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.deepEqual(served.map(k => k.keyName), [])
   })
 
-  it('PR source removes an orphan (tag, source) when the key disappears, preserving main scope (수정 B)', async () => {
-    // 과거 PR-1이 claim했다가 코드에서 사라진 키. PR-1 sync(추출 0건)에서 (web4, PR-1) orphan을
-    // 제거해야 _remoteCount(PR-1)이 0이 되어 체크런이 풀린다. (web4, main)과 공유 context는 불변.
+  it('PR source self-cleans its (tag, source) claim when the key disappears from local', async () => {
+    // PR이 도중에 추가했다가 도중에 제거한 키 — 자기 (web4, PR-1) claim을 즉시 정리한다.
+    // 단일-source 모델이라 main scope와 동시 공존하는 시나리오는 없다; 키는 PR-1 unclaim 후 orphan이 되고
+    // 데이터(context 포함)는 보존되어 누가 다시 claim하면 부활한다.
     await seedKeys(projectId!, [{
       keyName: 'orphan.key',
-      tags: [{ tag: 'web4', source: 'PR-1' }, { tag: 'web4', source: 'main' }],
+      tags: [{ tag: 'web4', source: 'PR-1' }],
       metadata: [{ tag: 'web4', metaKey: 'context', metaValue: JSON.stringify(['shared']) }],
     }])
 
     const config = buildL10nConfig(projectId!, { source: 'main' })
-    // PR이 더 이상 이 키를 추출하지 않음
     await syncTransToL10nStorage(
       config, buildDomainConfig(), 'web4', [], {}, false, { source: 'PR-1' },
     )
 
+    // PR-1 scope는 비었고 key는 orphan으로 보존
     const prScope = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'PR-1')
-    assert.deepEqual(prScope.map(k => k.keyName), [], 'orphan PR-1 claim removed')
+    assert.deepEqual(prScope.map(k => k.keyName), [])
 
-    const mainScope = await apiClient.listKeysToServeByTag(projectId!, 'web4', 'main')
-    assert.ok(mainScope.map(k => k.keyName).includes('orphan.key'), 'main scope preserved')
-
-    // 키 자체는 삭제되지 않고 공유 context도 유지
     const [k] = await apiClient.listAllKeysToServe(projectId!)
+    assert.equal(k.keyName, 'orphan.key')
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+    // context는 데이터 보존 — 재claim 시 부활
     const ctxMeta = k.metadata.find(m => m.tag === 'web4' && m.metaKey === 'context')
     assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['shared'])
+  })
+
+  it('full sync unclaims (tag) when key is gone locally (context-less)', async () => {
+    // context-less 도메인에서 로컬에 없는 키는 즉시 source-omitted removeTags로 (tag) unclaim한다.
+    // 단일-source 모델이라 (tag) PK당 source는 하나뿐 — source 생략은 그 한 row를 깨끗이 제거한다.
+    await seedKeys(projectId!, [{
+      keyName: 'gone.key',
+      tags: [{ tag: 'web4', source: 'main' }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web4', [], {}, false)
+
+    // 키는 orphan으로 보존(데이터 유지, 태그만 제거)
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    assert.equal(k.keyName, 'gone.key')
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+
+    // tag 필터 serve는 orphan을 자연 제외
+    const served = await apiClient.listKeysToServeByTag(projectId!, 'web4')
+    assert.deepEqual(served.map(k => k.keyName), [])
+  })
+
+  it('full sync removes all orphan contexts and then unclaims (tag) (context-ful, multi-context)', async () => {
+    // Android 같은 context-ful 도메인에서 서버 context 여러 개가 로컬에서 모두 사라진 케이스.
+    // 모든 orphan context를 빠짐없이 제거해야 한다 — Pass 1에서 baseMetadata를 누적하지 않으면
+    // pushSetMetadata replace 때문에 마지막 iteration만 살아남는 회귀가 있었다. 모든 context가
+    // 빠지면 그 다음 (tag) source-omitted unclaim까지 동일 PUT으로 보낸다.
+    await seedKeys(projectId!, [{
+      keyName: '취소',
+      tags: [{ tag: 'android-likey', source: 'main' }],
+      metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a', 'b']) }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'android-likey', [], {}, false)
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    assert.equal(k.keyName, '취소')
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+    const ctxMeta = k.metadata.find(m => m.tag === 'android-likey' && m.metaKey === 'context')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), [])
+  })
+
+  it('full sync removes only missing contexts and preserves the tag when others remain', async () => {
+    // 로컬에 일부 context가 남아 있으면 빠진 context만 제거하고 (tag, source)는 그대로 둔다.
+    // context가 줄어들 뿐 키는 여전히 코드에서 사용되므로 unclaim 대상이 아니다.
+    await seedKeys(projectId!, [{
+      keyName: '취소',
+      tags: [{ tag: 'android-likey', source: 'main' }],
+      metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a', 'b']) }],
+    }])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(
+      config, buildDomainConfig(), 'android-likey',
+      [key('취소', { context: 'a' })], {}, false,
+    )
+
+    const [k] = await apiClient.listAllKeysToServe(projectId!)
+    // 태그는 보존
+    assert.deepEqual(
+      k.tags.map(t => ({ tag: t.tag, source: t.source })),
+      [{ tag: 'android-likey', source: 'main' }],
+    )
+    // 'b'만 제거되고 'a'는 남음
+    const ctxMeta = k.metadata.find(m => m.tag === 'android-likey' && m.metaKey === 'context')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['a'])
+  })
+
+  it('tag-filtered fetch isolates cleanup — never touches keys tagged with a different tag', async () => {
+    // sync는 자신이 다루는 태그에만 영향을 준다. 같은 프로젝트에 다른 태그(web)로만 존재하는 키는
+    // tag-filtered fetch에서 보이지 않으므로 web4 sync의 Pass 1 cleanup이 절대 건드릴 수 없다.
+    await seedKeys(projectId!, [
+      { keyName: 'only.web4', tags: [{ tag: 'web4', source: 'main' }] },
+      { keyName: 'only.web', tags: [{ tag: 'web', source: 'main' }] },
+    ])
+
+    const config = buildL10nConfig(projectId!, { source: 'main' })
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web4', [], {}, false)
+
+    const all = await apiClient.listAllKeysToServe(projectId!)
+    const w4 = all.find(k => k.keyName === 'only.web4')!
+    const w = all.find(k => k.keyName === 'only.web')!
+
+    // only.web4는 전체 sync의 (web4, *) unclaim으로 orphan이 된다
+    assert.deepEqual(w4.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+    // only.web은 다른 태그라 완전 보존
+    assert.deepEqual(
+      w.tags.map(t => ({ tag: t.tag, source: t.source })),
+      [{ tag: 'web', source: 'main' }],
+    )
   })
 })

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -53,8 +53,8 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(creatingKeys[0].tags, [{ tag: 'backend', source: 'main' }])
   })
 
-  it('should NOT claim (tag, source) for non-authoritative source when no new context is added', () => {
-    // A PR-scoped sync (non-authoritative source) extracts the entire local file, so every
+  it('should NOT claim (tag, source) for specific source sync when no new context is added', () => {
+    // A PR-scoped sync (specific source sync) extracts the entire local file, so every
     // key flows through Pass 2 even if the PR did not touch it. To avoid PR-N claiming every
     // key in the project — which previously caused ~2000-key "upload" notifications on
     // PRs that only deleted a handful of strings — claim must require an actual new context.
@@ -66,14 +66,14 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
     assert.equal(updatingKeys.length, 0)
   })
 
-  it('should NOT claim (tag, source) for non-authoritative source when only references change', () => {
+  it('should NOT claim (tag, source) for specific source sync when only references change', () => {
     // References (file:line) drift with PR diffs but are not exposed by the source filter,
     // so PR-N must not claim ownership just because file locations changed.
     const keyEntries: KeyEntry[] = [
@@ -90,7 +90,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-1692', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-1692', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     // refs are updated, but no (tag, source) claim
@@ -100,7 +100,7 @@ describe('buildKeyChanges', () => {
     assert.ok(refsMeta != null)
   })
 
-  it('should NOT claim (tag, source) for non-authoritative source when only description changes', () => {
+  it('should NOT claim (tag, source) for specific source sync when only description changes', () => {
     // Description metadata is not exposed by the source filter either, so a description-only
     // change does not warrant a PR-N claim.
     const keyEntries: KeyEntry[] = [
@@ -114,7 +114,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-42', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-42', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(updatingKeys.length, 1)
@@ -132,7 +132,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-123', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -172,7 +172,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-99', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-99', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -287,10 +287,10 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys.length, 0)
   })
 
-  it('Pass 1 (authoritative): drops the orphan context and then unclaims (tag, *) source-agnostically', () => {
+  it('Pass 1 (full sync): drops the orphan context and then unclaims (tag, *) source-agnostically', () => {
     // context-ful 도메인에서 서버에 등록된 context가 로컬에 더 이상 없는 경우. 우선 context metadata에서
     // 빠진 context를 제거하고, 한 키의 모든 context가 사라지면 (tag, *)를 source 무관 일괄 unclaim한다.
-    // 권위 source는 "이 프로젝트가 관리하는 키"의 권위를 가지므로 다른 source의 (tag, source) 행도 함께
+    // 전체 sync는 이 태그 전체 범위를 정리할 권한이 있어 다른 source의 (tag, source) 행도 함께
     // 정리한다 — 키 자체는 데이터 보존(orphan) 상태로 남는다.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
@@ -312,8 +312,8 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(JSON.parse(ctxMeta.metaValue), [])
   })
 
-  it('Pass 1 (authoritative): unclaims (tag, *) regardless of which source claimed it', () => {
-    // 권위 source는 tag 단위 정리 책임을 가진다. 다른 source(예: 폐기된 PR-N)가 단 (tag, source) 행도
+  it('Pass 1 (full sync): unclaims (tag, *) regardless of which source claimed it', () => {
+    // 전체 sync는 tag 단위 정리 책임을 가진다. 다른 source(예: 폐기된 PR-N)가 단 (tag, source) 행도
     // 함께 unclaim된다 — server는 source 생략된 removeTags를 (key, tag)의 모든 row 제거로 해석한다.
     // 키 자체는 orphan으로 보존되어 같은 키가 다시 등장하면 부활한다.
     const keyEntries: KeyEntry[] = []
@@ -333,7 +333,7 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys[0].setMetadata, undefined)
   })
 
-  it('Pass 1 (authoritative): context-less domain unclaims (tag, *) immediately when key is gone locally', () => {
+  it('Pass 1 (full sync): context-less domain unclaims (tag, *) immediately when key is gone locally', () => {
     // web4 vue-i18n 처럼 context metadata가 없는 도메인에서, 로컬 추출에 없는 키는 즉시 unclaim한다.
     // 기존 코드는 context iteration을 거치므로 context-less 도메인의 orphan을 정리하지 못했다.
     const keyEntries: KeyEntry[] = []
@@ -396,7 +396,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-77', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-77', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(updatingKeys.length, 1)
@@ -539,7 +539,7 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(JSON.parse(contextMeta.metaValue), ['a:one', 'b:two'])
   })
 
-  it('Pass 1: non-authoritative source drops its own orphan (tag, source) but never touches shared context', () => {
+  it('Pass 1: specific source sync drops its own orphan (tag, source) but never touches shared context', () => {
     // A PR source claimed the key on a previous sync, but the PR's local no longer extracts it.
     // The PR-N tag is now an orphan: it keeps _remoteCount/source filter surfacing the key,
     // freezing the check run on "Translations are not applied". So the PR's own (tag, source)
@@ -558,7 +558,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-7', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-7', 'backend', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(updatingKeys.length, 1)
@@ -569,7 +569,7 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys[0].addTags, undefined)
   })
 
-  it('non-authoritative source claims an existing key first introduced by this tag (no context, e.g. web4)', () => {
+  it('specific source sync claims an existing key first introduced by this tag (no context, e.g. web4)', () => {
     // Regression (#346): a context-less domain like likey-web-4 vue-i18n never produces a new
     // context, so the old `contextAdded`-only rule meant a PR could never claim an existing key.
     // When the key already exists on the server under another tag (created by a different repo)
@@ -583,7 +583,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -591,7 +591,7 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(updatingKeys[0].addTags, [{ tag: 'web4', source: 'PR-1' }])
   })
 
-  it('non-authoritative source does NOT claim an existing key this tag already owns (no flood)', () => {
+  it('specific source sync does NOT claim an existing key this tag already owns (no flood)', () => {
     // "불러오는 중..." 유형: main이 이미 (web4, main)으로 소유하고 번역까지 끝난 키. PR이 단순히
     // 추출에 포함시켰다고 claim하면 PR마다 모든 web4 키가 잡혀 #346 폭주가 재현된다. 자기 태그가
     // 이미 있으므로 claim하지 않아야 한다.
@@ -603,14 +603,14 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
     assert.equal(updatingKeys.length, 0)
   })
 
-  it('non-authoritative source still claims when a new context is added (context-ful domain, e.g. Android)', () => {
+  it('specific source sync still claims when a new context is added (context-ful domain, e.g. Android)', () => {
     // Regression guard for the original #346 fix: in a context-ful domain, adding a brand-new
     // context to an existing key must still claim (tag, source) via the contextAdded path,
     // independent of the new hasAnyOwnTag path.
@@ -623,7 +623,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-9', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-9', 'android-likey', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -634,7 +634,7 @@ describe('buildKeyChanges', () => {
     assert.deepEqual(JSON.parse(contextMeta.metaValue), ['a', 'b'])
   })
 
-  it('Pass 1 (non-authoritative): does NOT remove tag for a key still present in local extraction', () => {
+  it('Pass 1 (specific source): does NOT remove tag for a key still present in local extraction', () => {
     // The key carries its own (tag, source) claim and is still extracted locally → it is a live
     // claim, not an orphan, so Pass 1 must leave it alone (Pass 2 keeps the claim).
     const keyEntries = [createKeyEntry('살아있는키')]
@@ -646,14 +646,14 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     const removeTagUpdates = updatingKeys.filter(u => u.removeTags != null)
     assert.equal(removeTagUpdates.length, 0)
   })
 
-  it('Pass 1 (non-authoritative): leaves the key itself (and other-source tags) intact when dropping an orphan', () => {
+  it('Pass 1 (specific source): leaves the key itself (and other-source tags) intact when dropping an orphan', () => {
     // Removing the orphan PR-1 tag must not remove the (web4, main) tag nor delete the key.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
@@ -665,7 +665,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { creatingKeys, updatingKeys } = buildKeyChanges(
-      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isAuthoritativeSource */ false,
+      'PR-1', 'web4', keyEntries, {}, listedKeyMap, undefined, undefined, /* isFullSync */ false,
     )
 
     assert.equal(creatingKeys.length, 0)
@@ -675,9 +675,9 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys[0].setMetadata, undefined)
   })
 
-  it('Pass 1 (authoritative): unaffected by 수정 A/B — claims own tag for a key it does not yet own', () => {
-    // main is authoritative; even with the new hasAnyOwnTag path, authoritative short-circuits
-    // first, so a key it doesn't own yet is still claimed exactly as before.
+  it('Pass 1 (full sync): unaffected by 수정 A/B — claims own tag for a key it does not yet own', () => {
+    // full sync uses main as default source; even with the new hasAnyOwnTag path, isFullSync
+    // short-circuits first, so a key it doesn't own yet is still claimed exactly as before.
     const keyEntries = [createKeyEntry('취소')] // context null
     const listedKeyMap = {
       취소: createL10nKey('취소', {
@@ -686,7 +686,7 @@ describe('buildKeyChanges', () => {
     }
 
     const { updatingKeys } = buildKeyChanges(
-      'main', 'web4', keyEntries, {}, listedKeyMap, // isAuthoritativeSource defaults to true
+      'main', 'web4', keyEntries, {}, listedKeyMap, // isFullSync defaults to true
     )
 
     assert.equal(updatingKeys.length, 1)

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -287,10 +287,11 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys.length, 0)
   })
 
-  it('Pass 1: should only remove context for own source tags', () => {
-    // key has tag from 'main' source with context 'ctx1'
-    // but local keyEntries don't have this key with context 'ctx1'
-    // → should remove context and tag for 'main' source
+  it('Pass 1 (authoritative): drops the orphan context and then unclaims (tag, *) source-agnostically', () => {
+    // context-ful 도메인에서 서버에 등록된 context가 로컬에 더 이상 없는 경우. 우선 context metadata에서
+    // 빠진 context를 제거하고, 한 키의 모든 context가 사라지면 (tag, *)를 source 무관 일괄 unclaim한다.
+    // 권위 source는 "이 프로젝트가 관리하는 키"의 권위를 가지므로 다른 source의 (tag, source) 행도 함께
+    // 정리한다 — 키 자체는 데이터 보존(orphan) 상태로 남는다.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
       'removed.key': createL10nKey('removed.key', {
@@ -304,17 +305,21 @@ describe('buildKeyChanges', () => {
       'main', 'backend', keyEntries, {}, listedKeyMap,
     )
 
-    // Should have an update to remove context and tag
     assert.equal(updatingKeys.length, 1)
-    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend', source: 'main' }])
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend' }])
+    const ctxMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'context')
+    assert.ok(ctxMeta != null)
+    assert.deepEqual(JSON.parse(ctxMeta.metaValue), [])
   })
 
-  it('Pass 1: should not touch keys owned by different source', () => {
+  it('Pass 1 (authoritative): unclaims (tag, *) regardless of which source claimed it', () => {
+    // 권위 source는 tag 단위 정리 책임을 가진다. 다른 source(예: 폐기된 PR-N)가 단 (tag, source) 행도
+    // 함께 unclaim된다 — server는 source 생략된 removeTags를 (key, tag)의 모든 row 제거로 해석한다.
+    // 키 자체는 orphan으로 보존되어 같은 키가 다시 등장하면 부활한다.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
       'other.key': createL10nKey('other.key', {
         tags: [{ tag: 'backend', source: 'other-source' }],
-        metadata: [{ tag: 'backend', metaKey: 'context', metaValue: '' }],
       }),
     }
 
@@ -322,7 +327,31 @@ describe('buildKeyChanges', () => {
       'main', 'backend', keyEntries, {}, listedKeyMap,
     )
 
-    assert.equal(updatingKeys.length, 0)
+    assert.equal(updatingKeys.length, 1)
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend' }])
+    // 공유 context/description metadata는 건드리지 않는다 — 어차피 unclaim으로 자연 정리.
+    assert.equal(updatingKeys[0].setMetadata, undefined)
+  })
+
+  it('Pass 1 (authoritative): context-less domain unclaims (tag, *) immediately when key is gone locally', () => {
+    // web4 vue-i18n 처럼 context metadata가 없는 도메인에서, 로컬 추출에 없는 키는 즉시 unclaim한다.
+    // 기존 코드는 context iteration을 거치므로 context-less 도메인의 orphan을 정리하지 못했다.
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      'gone.key': createL10nKey('gone.key', {
+        id: 'key-2',
+        tags: [{ tag: 'web4', source: 'main' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'web4', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 1)
+    assert.equal(updatingKeys[0].keyId, 'key-2')
+    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'web4' }])
+    assert.equal(updatingKeys[0].setMetadata, undefined)
   })
 
   it('Pass 2: accumulates contexts when same keyName appears with multiple contexts (existing key)', () => {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -56,10 +56,14 @@ export async function syncTransToL10nStorage(
   const projectId = storageConfig.getProjectId()
   const configSource = storageConfig.getSource()
   const source = options?.source ?? configSource
-  // The configured source (e.g. 'main') is the authoritative one that owns metadata cleanup.
-  // Ephemeral sources like a PR scope must be add-only so they cannot strip contexts that
-  // other sources (notably 'main') still use — context metadata is shared per tag.
-  const isAuthoritativeSource = source === configSource
+  // 두 가지 sync 모드를 구분한다.
+  // - **전체 sync** (`source === configSource`, options.source 미지정): 이 태그의 모든 키를 대상으로
+  //   하는 sync. 로컬에 없는 키는 (tag) 자체를 source-omitted로 unclaim 가능. 새 키가 추가될 때
+  //   특정 PR이 아니므로 default source(configSource, 보통 'main')가 부여된다.
+  // - **특정 source sync** (`options.source = 'PR-N'`): PR 스코프 sync. 자기 (tag, source) 범위만
+  //   관리하고 다른 source의 claim/공유 metadata는 절대 건드리지 않는다.
+  // main이 특별한 게 아니라, "특정 PR이 아닐 때 default source가 main"인 것일 뿐 main과 PR-N은 동등.
+  const isFullSync = source === configSource
   const url = storageConfig.getUrl()
 
   const token = process.env.TPC_AGENT_TOKEN
@@ -87,7 +91,7 @@ export async function syncTransToL10nStorage(
 
   // 2. 로컬과 비교하여 create/update 대상 분류
   const { creatingKeys, updatingKeys } = buildKeyChanges(
-    source, tag, keyEntries, allTransData, listedKeyMap, localeSyncMap, options, isAuthoritativeSource,
+    source, tag, keyEntries, allTransData, listedKeyMap, localeSyncMap, options, isFullSync,
   )
 
   // 3. 서버 번역을 로컬에 반영
@@ -191,7 +195,7 @@ export function buildKeyChanges(
   listedKeyMap: { [keyName: string]: L10nKeyToServe },
   localeSyncMap?: { [locale: string]: string },
   options?: SyncerOptions,
-  isAuthoritativeSource: boolean = true,
+  isFullSync: boolean = true,
 ): {
   creatingKeys: CreateL10nKeyInput[],
   updatingKeys: UpdateL10nKeyInput[],
@@ -217,15 +221,16 @@ export function buildKeyChanges(
   }
 
   // Pass 1: 서버에 있는(이미 tag-filtered) 키 중 로컬 추출에 없는 것의 정리.
-  // - 권위 source(config의 source): "이 프로젝트가 관리하는 키"의 권위를 가지므로 (tag, *)를
-  //   source 무관 일괄 unclaim한다. context가 있는 도메인(Android 등)은 우선 로컬에 없는 context를
-  //   제거하고 context가 하나도 남지 않을 때만 unclaim한다. context-less 도메인(web4 vue-i18n 등)은
-  //   key 단위로 즉시 unclaim한다.
-  // - 비권위 source(예: PR-N): 공유 context는 절대 건드리지 않되, 로컬 추출에서 완전히 사라진 키의
-  //   자기 (tag, source) 태그만 제거한다. 이렇게 하면 과거 PR가 claim했다가 코드에서 삭제된 orphan이
-  //   _remoteCount/source filter에 남아 체크런이 고착되는 회귀를 막는다. 자기 태그 제거는 다른
-  //   source에 영향을 주지 않아 안전하다.
-  if (isAuthoritativeSource) {
+  // - 전체 sync: 이 태그의 모든 키를 대상으로 하므로 로컬에 없는 키의 (tag) 자체를 source-omitted로
+  //   일괄 unclaim한다. context가 있는 도메인(Android 등)은 우선 로컬에 없는 context를 제거하고
+  //   context가 하나도 남지 않을 때만 unclaim한다. context-less 도메인(web4 vue-i18n 등)은 key
+  //   단위로 즉시 unclaim한다. PR 1161 단일-source 모델에서 (tag) PK당 source는 하나뿐이므로
+  //   source 생략은 그 한 row를 깨끗이 제거하며, 누구든 점유 중인 claim도 같이 정리된다.
+  // - 특정 source sync(예: --source PR-N): 공유 context는 절대 건드리지 않되, 로컬 추출에서 완전히
+  //   사라진 키의 자기 (tag, source) 태그만 제거한다. PR이 도중 추가했다가 도중 제거한 키의 자기
+  //   claim을 정리해 PR 체크런이 stale orphan으로 고착되는 회귀(#358)를 막는다. 자기 태그 제거는
+  //   다른 source에 영향을 주지 않아 안전하다.
+  if (isFullSync) {
     for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
       const serverContexts = getContextsFromMetadata(listedKey.metadata, tag)
 
@@ -315,20 +320,20 @@ export function buildKeyChanges(
       const refsChanged = (mergedRefs.length > 0 || existingRefEntry != null)
         && (existingRefEntry == null || existingRefEntry.metaValue !== mergedRefsValue)
 
-      // 비권위 source(PR-N 등)의 claim 조건. 단순히 keyEntries에 키를 포함시킨 것만으로 모든 키에
+      // 특정 source sync(PR-N 등)의 claim 조건. 단순히 keyEntries에 키를 포함시킨 것만으로 모든 키에
       // PR-N 태그를 붙이면, PR scope sync마다 모든 키가 update 대상으로 잡혀 storage에 폭주 알림이
-      // 발생한다(#346). 그래서 비권위 source는 다음 중 하나일 때만 claim한다:
+      // 발생한다(#346). 그래서 특정 source sync는 다음 중 하나일 때만 claim한다:
       //   - contextAdded: 키에 새 context를 추가 (Android에서 동일 원문을 새 <string name>에 쓰는 경우).
       //   - !hasAnyOwnTag: 이 태그가 이 키를 처음 다룸. 다른 repo가 만든 기존 키를 이 도메인이 처음
       //     사용하기 시작하는 마이그레이션 케이스. context가 없는 도메인(예: web4 vue-i18n)은 contextAdded가
       //     영영 false라, 이 신호가 없으면 기존 키를 절대 claim하지 못한다(회귀). 폭주는 발생하지 않는데,
       //     이 도메인이 이미 다루던 키는 (tag, main 등) 자기 태그를 가져 hasAnyOwnTag가 true이기 때문이다.
       // description/references 변경은 source filter에 노출되지 않아 PR apply에 propagate할 필요가 없으므로
-      // claim 대상에서 제외한다. 권위 source(예: main)는 tag ownership 관리 책임이 있어 자기 (tag, source)가
-      // 없으면 항상 claim(isAuthoritativeSource 단락평가로 동작 불변).
+      // claim 대상에서 제외한다. 전체 sync는 tag ownership 관리 책임이 있어 자기 (tag, source)가 없으면
+      // 항상 claim(isFullSync 단락평가로 동작 불변).
       const hasOwnSourceTag = hasTag(listedKey.tags, tag, source)
       const hasAnyOwnTag = hasTagAnySource(listedKey.tags, tag)
-      const needsTagAdd = !hasOwnSourceTag && (isAuthoritativeSource || contextAdded || !hasAnyOwnTag)
+      const needsTagAdd = !hasOwnSourceTag && (isFullSync || contextAdded || !hasAnyOwnTag)
 
       if (needsTagAdd || metaUpdates.length > 0 || refsChanged) {
         let updating = updatingKeyMap[entryKey]

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -17,6 +17,7 @@ import type {
   L10nKeyMetadata,
   L10nKeyTag,
   L10nKeyToServe,
+  RemoveTagInput,
   UpdateL10nKeyInput,
 } from './api-types.js'
 import {
@@ -71,8 +72,14 @@ export async function syncTransToL10nStorage(
 
   const apiClient = new L10nStorageApiClient(url, token)
 
-  // 1. l10n-storage에서 정책 적용된 키 전체 조회 (keys-to-serve)
-  const listedKeys = await apiClient.listAllKeysToServe(projectId)
+  // 1. 이 sync가 다루는 태그가 달린 키만 l10n-storage에서 조회 (keys-to-serve, tag-filtered).
+  // 핵심 원칙: l10n-storage 호출은 항상 "태그"를 동반한다 — 이 프로젝트가 관리하는 키의 범위.
+  // tag 필터는 orphan(어떤 태그/source에서도 claim되지 않은 키)을 자연 제외하므로, 결과는
+  // "이 태그로 claim된 키"의 정확한 집합이다. 로컬 추출에 없는 키는 unclaim 대상이 된다.
+  // 로컬에는 있지만 listedKeyMap에 없는 키는 (a) 정말 새 키이거나 (b) 다른 태그로만 존재하는
+  // 또는 orphan으로 부활시킬 키다 — 둘 다 Pass 2의 createKeys 경로가 서버 측에서 처리한다
+  // (keyName 중복 시 서버가 자동으로 add-tag로 부활시킨다).
+  const listedKeys = await apiClient.listKeysToServeByTag(projectId, tag)
   const listedKeyMap: { [keyName: string]: L10nKeyToServe } = {}
   for (const key of listedKeys) {
     listedKeyMap[key.keyName] = key
@@ -109,7 +116,7 @@ function pushAddTag(updating: UpdateL10nKeyInput, tag: L10nKeyTag): void {
   updating.addTags.push(tag)
 }
 
-function pushRemoveTag(updating: UpdateL10nKeyInput, tag: L10nKeyTag): void {
+function pushRemoveTag(updating: UpdateL10nKeyInput, tag: RemoveTagInput): void {
   if (!updating.removeTags) updating.removeTags = []
   updating.removeTags.push(tag)
 }
@@ -209,37 +216,55 @@ export function buildKeyChanges(
     else entriesByKeyName.set(ke.key, [ke])
   }
 
-  // Pass 1: 서버에 있고 우리 source 태그가 있는 키의 정리.
-  // - 권위 source(config의 source): 로컬에 없는 context를 제거하고, context가 모두 사라지면 태그도 제거.
-  //   Context metadata는 (tag) 단위로 모든 source가 공유하므로 이 cleanup은 권위 source만 수행한다.
+  // Pass 1: 서버에 있는(이미 tag-filtered) 키 중 로컬 추출에 없는 것의 정리.
+  // - 권위 source(config의 source): "이 프로젝트가 관리하는 키"의 권위를 가지므로 (tag, *)를
+  //   source 무관 일괄 unclaim한다. context가 있는 도메인(Android 등)은 우선 로컬에 없는 context를
+  //   제거하고 context가 하나도 남지 않을 때만 unclaim한다. context-less 도메인(web4 vue-i18n 등)은
+  //   key 단위로 즉시 unclaim한다.
   // - 비권위 source(예: PR-N): 공유 context는 절대 건드리지 않되, 로컬 추출에서 완전히 사라진 키의
   //   자기 (tag, source) 태그만 제거한다. 이렇게 하면 과거 PR가 claim했다가 코드에서 삭제된 orphan이
-  //   _remoteCount/source filter에 영구히 남아 체크런이 고착되는 회귀를 막는다. 자기 태그 제거는 다른
+  //   _remoteCount/source filter에 남아 체크런이 고착되는 회귀를 막는다. 자기 태그 제거는 다른
   //   source에 영향을 주지 않아 안전하다.
   if (isAuthoritativeSource) {
     for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
-      if (!hasTag(listedKey.tags, tag, source)) continue
+      const serverContexts = getContextsFromMetadata(listedKey.metadata, tag)
 
-      for (const keyContext of getContextsFromMetadata(listedKey.metadata, tag)) {
+      if (serverContexts.length === 0) {
+        // context-less 도메인: 로컬에 없는 키면 즉시 (tag, *) unclaim.
+        if (entriesByKeyName.has(keyName)) continue
+        let updating = updatingKeyMap[keyName]
+        if (!updating) {
+          updating = { keyId: listedKey.id }
+          updatingKeyMap[keyName] = updating
+        }
+        pushRemoveTag(updating, { tag })
+        continue
+      }
+
+      // context-ful 도메인: 로컬에 없는 context는 제거하고, 다 빠지면 (tag, *) unclaim.
+      let touched = false
+      for (const keyContext of serverContexts) {
         const keyEntry = keys.find(keyContext, keyName)
-        if (keyEntry == null) {
-          let updating = updatingKeyMap[keyName]
-          if (!updating) {
-            updating = { keyId: listedKey.id }
-            updatingKeyMap[keyName] = updating
-          }
-          const contextMeta = buildContextMetadataRemoving(listedKey.metadata, tag, keyContext)
-          if (contextMeta) {
-            pushSetMetadata(updating, contextMeta)
-          }
-          // 모든 context가 제거되면 태그도 제거
-          const remaining = getContextsFromMetadata(
-            mergeMetadata(listedKey.metadata, updating.setMetadata ?? []),
-            tag,
-          )
-          if (remaining.length === 0) {
-            pushRemoveTag(updating, { tag, source })
-          }
+        if (keyEntry != null) continue
+        let updating = updatingKeyMap[keyName]
+        if (!updating) {
+          updating = { keyId: listedKey.id }
+          updatingKeyMap[keyName] = updating
+        }
+        const contextMeta = buildContextMetadataRemoving(listedKey.metadata, tag, keyContext)
+        if (contextMeta) {
+          pushSetMetadata(updating, contextMeta)
+          touched = true
+        }
+      }
+      if (touched) {
+        const updating = updatingKeyMap[keyName]!
+        const remaining = getContextsFromMetadata(
+          mergeMetadata(listedKey.metadata, updating.setMetadata ?? []),
+          tag,
+        )
+        if (remaining.length === 0) {
+          pushRemoveTag(updating, { tag })
         }
       }
     }

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -242,30 +242,28 @@ export function buildKeyChanges(
       }
 
       // context-ful 도메인: 로컬에 없는 context는 제거하고, 다 빠지면 (tag, *) unclaim.
+      // 여러 context가 한 번에 빠질 때 buildContextMetadataRemoving이 매번 원본 listedKey.metadata만
+      // 보고 "그 context 하나만 빠진" 결과를 만들면 pushSetMetadata의 replace로 마지막 iteration만
+      // 살아남는다. baseMetadata를 누적해 매 iteration 직전 상태를 기준으로 다음 context를 빼야 모든
+      // orphan context가 빠진다.
+      let baseMetadata = listedKey.metadata
       let touched = false
       for (const keyContext of serverContexts) {
         const keyEntry = keys.find(keyContext, keyName)
         if (keyEntry != null) continue
+        const contextMeta = buildContextMetadataRemoving(baseMetadata, tag, keyContext)
+        if (contextMeta == null) continue
         let updating = updatingKeyMap[keyName]
         if (!updating) {
           updating = { keyId: listedKey.id }
           updatingKeyMap[keyName] = updating
         }
-        const contextMeta = buildContextMetadataRemoving(listedKey.metadata, tag, keyContext)
-        if (contextMeta) {
-          pushSetMetadata(updating, contextMeta)
-          touched = true
-        }
+        pushSetMetadata(updating, contextMeta)
+        baseMetadata = mergeMetadata(baseMetadata, [contextMeta])
+        touched = true
       }
-      if (touched) {
-        const updating = updatingKeyMap[keyName]!
-        const remaining = getContextsFromMetadata(
-          mergeMetadata(listedKey.metadata, updating.setMetadata ?? []),
-          tag,
-        )
-        if (remaining.length === 0) {
-          pushRemoveTag(updating, { tag })
-        }
+      if (touched && getContextsFromMetadata(baseMetadata, tag).length === 0) {
+        pushRemoveTag(updatingKeyMap[keyName]!, { tag })
       }
     }
   } else {


### PR DESCRIPTION
## Summary

l10n-storage syncer를 PR 1161 단일-source 모델에 맞춰 정리한다.

- **tag-filtered fetch**: `listAllKeysToServe` → `listKeysToServeByTag(projectId, tag)`. l10n-storage 호출은 항상 tag를 동반한다 — "이 프로젝트가 관리하는 키"의 범위.
- **전체 sync의 (tag, *) source-omitted unclaim**: 권위/비권위 framing 폐기. 전체 sync(`source === configSource`)는 이 태그의 모든 키를 대상으로 하므로 로컬에 없는 키의 (tag) 자체를 source-omitted로 일괄 unclaim한다. PR 1161 단일-source 모델에서 (key, tag) PK당 source는 하나뿐이라 source 생략은 자연스러운 정리.
- **context-less 도메인 cleanup 보완**: web4 vue-i18n처럼 context metadata가 없는 도메인에서도 로컬에 없는 키를 즉시 unclaim. 기존 코드는 context iteration을 거치는 구조라 context-less 도메인의 orphan을 정리하지 못했다.
- **특정 source sync(PR 스코프)의 self-cleanup은 그대로**: #358 회귀 방지 로직 유지. 자기 (tag, source)만 정리하고 공유 context/다른 source는 절대 건드리지 않는다.
- **Pass 1 multi-context 누적 버그 수정**: 여러 context가 한 번에 로컬에서 사라진 경우 `pushSetMetadata`의 replace로 마지막 iteration만 살아남던 잠재 회귀. `baseMetadata`를 누적해 모든 orphan context가 빠지도록 수정.
- **`isAuthoritativeSource` → `isFullSync`**: main과 PR-N은 동등하다는 사실에 맞춘 네이밍·주석 정리. 동작 불변.
- **per-PR backend image CI 메커니즘**: tpc-workspace에서 포팅. PR body의 `tpc-agent-tag: <tag>` 마커로 임의 tpc-agent PR 빌드 이미지로 e2e 가능.

## Dependencies

- tpc-agent#1161 (l10n-storage orphan + 단일-source 모델). 본 PR의 syncer 변경은 이 server PR이 머지·배포되어야 정상 동작한다.

## Test plan

- [x] `npm run lint` / 모노레포 전체 typecheck 통과
- [x] unit 47/47 그린
- [x] e2e 26/26 그린 (로컬 tpc-agent PR 1161 backend 대상)
- 머지 후: secret `BACKEND_IMAGE`가 tpc-agent#1161 머지 이후 main 이미지로 업데이트되었는지 확인. 그 전까지 본 PR e2e는 `tpc-agent-tag: pr-1161` 마커로 PR 빌드 이미지를 사용한다.

tpc-agent-tag: pr-1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
