### PR TITLE
feat(cli): add `check --report <path>` for untranslated key reporting

### DIFF
--- a/packages/cli/src/l10n.ts
+++ b/packages/cli/src/l10n.ts
@@ -242,6 +242,14 @@ async function run() {
     tagMetadata?: Record<string, string>,
     source?: string,
     contexts?: string,
+    report?: string,
+  }
+  type CheckReportDomain = {
+    domain: string,
+    tag: string,
+    link?: string,
+    untranslatedCount: number,
+    untranslatedKeys: string[],
   }
   program.command('check')
     .description('Check all translated')
@@ -252,9 +260,12 @@ async function run() {
     .option('--tag-metadata <key=value>', 'tag-specific metadata to apply when creating keys (repeatable)', collectKeyValue, {})
     .option('--source <source>', 'source identifier for tag ownership (l10n-storage)')
     .option('-c, --contexts <contexts>', 'contexts to check (comma separated)')
+    .option('--report <path>', 'write a machine-readable JSON report of untranslated keys (suppresses stdout dump); pair with --source for translation links')
     .argument('[files...]', 'files to check, if not specified, all files will be checked')
     .action(async (files: string[], opts: CheckOptions, cmd: Command) => {
       const syncerOptions = buildSyncerOptions(opts)
+      const reportActive = opts.report != null
+      const reportDomains: CheckReportDomain[] = []
       await runSubCommand(cmd.name(), async (domainName, config, domainConfig, skipUpload) => {
         const cacheDir = domainConfig.getCacheDir()
         const locales = opts['locales'] ? opts['locales'].split(',') : domainConfig.getLocales()
@@ -308,6 +319,8 @@ async function run() {
           }
           return EntryCollection.loadEntries(keyEntries)
         })()
+        // 미번역 키를 locale 간 dedupe 하여 도메인 단위로 모은다 (--report 사용 시).
+        const untranslatedKeys = reportActive ? new Set<string>() : null
         for (const locale of locales) {
           const transPath = getTransPath(transDir, locale)
           const useUnverified = config.useUnverified(locale)
@@ -321,6 +334,11 @@ async function run() {
             }
             process.exitCode = 1
 
+            if (untranslatedKeys != null) {
+              untranslatedKeys.add(transEntry.key)
+              continue
+            }
+
             process.stdout.write(`[${locale}] ${specs.join(',')}\n`)
             const flag = transEntry.flag
             if (flag) {
@@ -333,7 +351,31 @@ async function run() {
             process.stdout.write(`message "${JSON.stringify(transEntry.messages)}"\n\n`)
           }
         }
+
+        // 미번역이 0건인 도메인은 리포트에서 제외한다.
+        if (untranslatedKeys != null && untranslatedKeys.size > 0) {
+          const keyNames = [...untranslatedKeys]
+          reportDomains.push({
+            domain: domainName,
+            tag,
+            // source 가 있어야 tag/source 뷰 링크를 만들 수 있다. 없으면 link 생략.
+            ...(opts.source != null
+              ? { link: config.getL10nStorageConfig().getTranslationLink(tag, opts.source) }
+              : {}),
+            untranslatedCount: keyNames.length,
+            untranslatedKeys: keyNames,
+          })
+        }
       })
+
+      if (reportActive) {
+        const report = {
+          source: opts.source ?? null,
+          domains: reportDomains,
+        }
+        await fsp.writeFile(opts.report!, JSON.stringify(report, null, 2) + '\n', { encoding: 'utf-8' })
+        log.info(cmd.name(), `wrote untranslated report to ${opts.report}`)
+      }
     })
 
   type ExtractKeysOptions = {

--- a/packages/core/l10nrc.schema.json
+++ b/packages/core/l10nrc.schema.json
@@ -245,6 +245,10 @@
         "url": {
           "description": "Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var",
           "type": "string"
+        },
+        "web-url": {
+          "description": "Base URL of the TPC Space web app (used to build translation links). Can be overridden by TPC_SPACE_URL env var",
+          "type": "string"
         }
       },
       "required": [

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { L10nStorageConfig } from './config.js'
+
+describe('L10nStorageConfig', () => {
+  const savedSpaceUrl = process.env.TPC_SPACE_URL
+  beforeEach(() => {
+    delete process.env.TPC_SPACE_URL
+  })
+  afterEach(() => {
+    if (savedSpaceUrl === undefined) {
+      delete process.env.TPC_SPACE_URL
+    } else {
+      process.env.TPC_SPACE_URL = savedSpaceUrl
+    }
+  })
+
+  describe('getWebUrl', () => {
+    it('falls back to the default when neither env nor config is set', () => {
+      const sc = new L10nStorageConfig({ projectId: 'p' })
+      assert.equal(sc.getWebUrl(), 'https://space.tpcground.com')
+    })
+
+    it('uses config web-url over the default', () => {
+      const sc = new L10nStorageConfig({ 'projectId': 'p', 'web-url': 'https://space.example.com' })
+      assert.equal(sc.getWebUrl(), 'https://space.example.com')
+    })
+
+    it('prefers TPC_SPACE_URL env over config and default', () => {
+      process.env.TPC_SPACE_URL = 'https://env.example.com'
+      const sc = new L10nStorageConfig({ 'projectId': 'p', 'web-url': 'https://space.example.com' })
+      assert.equal(sc.getWebUrl(), 'https://env.example.com')
+    })
+
+    it('strips trailing slashes', () => {
+      const sc = new L10nStorageConfig({ 'projectId': 'p', 'web-url': 'https://space.example.com//' })
+      assert.equal(sc.getWebUrl(), 'https://space.example.com')
+    })
+  })
+
+  describe('getTranslationLink', () => {
+    it('builds a tag/source scoped link with a literal slash', () => {
+      const sc = new L10nStorageConfig({ projectId: 'proj-123' })
+      assert.equal(
+        sc.getTranslationLink('backend', 'PR-7676'),
+        'https://space.tpcground.com/l10n/translations?project=proj-123&tagSource=backend/PR-7676',
+      )
+    })
+
+    it('uses the resolved web url', () => {
+      process.env.TPC_SPACE_URL = 'https://env.example.com/'
+      const sc = new L10nStorageConfig({ projectId: 'proj-123' })
+      assert.equal(
+        sc.getTranslationLink('email', 'PR-1'),
+        'https://env.example.com/l10n/translations?project=proj-123&tagSource=email/PR-1',
+      )
+    })
+  })
+})

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -32,6 +32,12 @@ describe('L10nStorageConfig', () => {
       assert.equal(sc.getWebUrl(), 'https://env.example.com')
     })
 
+    it('treats an empty env var as unset and falls back', () => {
+      process.env.TPC_SPACE_URL = ''
+      const sc = new L10nStorageConfig({ 'projectId': 'p', 'web-url': 'https://space.example.com' })
+      assert.equal(sc.getWebUrl(), 'https://space.example.com')
+    })
+
     it('strips trailing slashes', () => {
       const sc = new L10nStorageConfig({ 'projectId': 'p', 'web-url': 'https://space.example.com//' })
       assert.equal(sc.getWebUrl(), 'https://space.example.com')

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -400,6 +400,8 @@ export class ValidationConfig {
 type L10nStorageConf = {
   /** Base URL of the tpc-agent service. Can be overridden by TPC_AGENT_URL env var */
   'url'?: string,
+  /** Base URL of the TPC Space web app (used to build translation links). Can be overridden by TPC_SPACE_URL env var */
+  'web-url'?: string,
   'projectId': string,
   /** Source identifier for tag ownership */
   'source'?: string,
@@ -421,8 +423,23 @@ export class L10nStorageConfig {
     return url
   }
 
+  getWebUrl(): string {
+    const url = process.env.TPC_SPACE_URL ?? this.sc['web-url'] ?? 'https://space.tpcground.com'
+    return url.replace(/\/+$/, '')
+  }
+
   getProjectId(): string {
     return this.sc.projectId
+  }
+
+  /**
+   * Build a link to the TPC Space translation view scoped to a tag/source pair,
+   * e.g. https://space.tpcground.com/l10n/translations?project=<id>&tagSource=<tag>/<source>
+   */
+  getTranslationLink(tag: string, source: string): string {
+    const project = encodeURIComponent(this.getProjectId())
+    const tagSource = `${encodeURIComponent(tag)}/${encodeURIComponent(source)}`
+    return `${this.getWebUrl()}/l10n/translations?project=${project}&tagSource=${tagSource}`
   }
 
   getSource(): string {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -424,7 +424,7 @@ export class L10nStorageConfig {
   }
 
   getWebUrl(): string {
-    const url = process.env.TPC_SPACE_URL ?? this.sc['web-url'] ?? 'https://space.tpcground.com'
+    const url = process.env.TPC_SPACE_URL || this.sc['web-url'] || 'https://space.tpcground.com'
     return url.replace(/\/+$/, '')
   }
 


### PR DESCRIPTION
## Summary
PR l10n 체크에서 미번역 정보를 머신 판독용으로 뽑아내기 위해 `l10n check`에 `--report <path>`를 추가합니다. 미번역 판정의 단일 소스인 `check --source`를 그대로 활용해 도메인별 미번역 키/갯수/번역 작업 링크를 JSON으로 출력합니다(workflow-storage의 PR summary 구성에 사용).

- **core**: `L10nStorageConfig.getWebUrl()` (`TPC_SPACE_URL` env > `l10n-storage.web-url` config > 기본 `https://space.tpcground.com`, 빈 값/후행 슬래시 정규화) 와 `getTranslationLink(tag, source)` 추가, 스키마에 optional `web-url` 필드 추가
- **cli**: `check --report <path>` — 도메인별 미번역 키를 locale 간 dedupe하여 JSON 파일로 1회 출력. `--source` 동반 시 `tagSource=tag/source` 뷰 링크 포함

동작 세부:
- `--report` 미지정 시 기존 동작(stdout 덤프, exitCode) 그대로 — 하위 호환
- `--report` 지정 시 stdout 덤프는 억제하되 미번역이 있으면 `exitCode=1`은 유지
- 미번역 0건 도메인은 `domains`에서 제외, `--source` 없으면 `link` 생략

리포트 형식:
```json
{
  "source": "PR-7676",
  "domains": [
    { "domain": "likey-backend", "tag": "backend", "link": "https://space.tpcground.com/l10n/translations?project=…&tagSource=backend/PR-7676", "untranslatedCount": 12, "untranslatedKeys": ["key.a", "key.b"] }
  ]
}
```

## Test plan
- [x] `getWebUrl()` 우선순위(env > config > default), 빈 문자열 폴백, 후행 슬래시 정규화 단위 테스트 (`packages/core/src/config.test.ts`)
- [x] `getTranslationLink()` 링크 형식(slash 리터럴 유지) 단위 테스트
- [ ] POST-MERGE: release-please 릴리스(core → cli npm publish) 후 workflow-storage의 `pr-l10n.yml`에서 새 버전으로 `--report` 사용하도록 연동

🤖 Generated with [Claude Code](https://claude.com/claude-code)