### PR TITLE
fix(syncer-l10n-storage): stop full sync from unclaiming keys absent from local

### DIFF
--- a/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
+++ b/packages/syncer-l10n-storage/src/e2e/l10n-storage.e2e.test.ts
@@ -172,7 +172,8 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.deepEqual(locales, ['en', 'ko'])
   })
 
-  it('removes context from metadata when local entry no longer has it', async () => {
+  it('full sync does NOT prune context even when a local entry no longer has it', async () => {
+    // 전체 sync는 "정말 삭제된 context"와 "미머지 PR이 쓰는 context"를 구분할 수 없어 context를 건드리지 않는다.
     await seedKeys(projectId!, [{
       keyName: 'ctx.key',
       tags: [{ tag: 'web', source: 'main' }],
@@ -180,20 +181,19 @@ describe('syncTransToL10nStorage (e2e)', () => {
     }])
 
     const config = buildL10nConfig(projectId!, { source: 'main' })
-    // ctx-A만 로컬에 남고 ctx-B는 사라진 상태
+    // ctx-A만 로컬에 남고 ctx-B는 사라졌지만, 전체 sync는 ctx-B를 제거하지 않는다
     await syncTransToL10nStorage(
       config, buildDomainConfig(), 'web', [key('ctx.key', { context: 'ctx-A' })], {}, false,
     )
 
     const [k] = await apiClient.listAllKeysToServe(projectId!)
     const ctxMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'context')
-    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['ctx-A'])
-    assert.equal(k.tags.length, 1, 'tag remains because ctx-A still belongs to main')
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['ctx-A', 'ctx-B'])
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [{ tag: 'web', source: 'main' }])
   })
 
-  it('removes the tag and empties context when all contexts are gone from local', async () => {
-    // 전체 sync가 로컬에 없는 마지막 context까지 다 빼고 나면 (tag, *)를 source-omitted로 unclaim한다.
-    // 단일-source 모델이라 "다른 source 보존" 시나리오는 정의상 존재하지 않는다.
+  it('full sync does NOT unclaim or empty context when all contexts are gone from local', async () => {
+    // 로컬에 키가 없어도 전체 sync는 unclaim하지 않는다 — 미머지 PR이 추가한 키일 수 있기 때문.
     await seedKeys(projectId!, [{
       keyName: 'ctx.gone.key',
       tags: [{ tag: 'web', source: 'main' }],
@@ -206,9 +206,9 @@ describe('syncTransToL10nStorage (e2e)', () => {
     )
 
     const [k] = await apiClient.listAllKeysToServe(projectId!)
-    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [{ tag: 'web', source: 'main' }])
     const ctxMeta = k.metadata.find(m => m.tag === 'web' && m.metaKey === 'context')
-    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), [])
+    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['ctx-only'])
   })
 
   it('attaches additionalTags + globalMetadata + tagMetadata when creating keys', async () => {
@@ -370,9 +370,8 @@ describe('syncTransToL10nStorage (e2e)', () => {
     assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['shared'])
   })
 
-  it('full sync unclaims (tag) when key is gone locally (context-less)', async () => {
-    // context-less 도메인에서 로컬에 없는 키는 즉시 source-omitted removeTags로 (tag) unclaim한다.
-    // 단일-source 모델이라 (tag) PK당 source는 하나뿐 — source 생략은 그 한 row를 깨끗이 제거한다.
+  it('full sync does NOT unclaim a key gone from local (context-less)', async () => {
+    // 전체 sync는 로컬에 없는 키를 unclaim하지 않는다 — 미머지 PR이 추가한 키와 구분할 수 없기 때문.
     await seedKeys(projectId!, [{
       keyName: 'gone.key',
       tags: [{ tag: 'web4', source: 'main' }],
@@ -381,79 +380,31 @@ describe('syncTransToL10nStorage (e2e)', () => {
     const config = buildL10nConfig(projectId!, { source: 'main' })
     await syncTransToL10nStorage(config, buildDomainConfig(), 'web4', [], {}, false)
 
-    // 키는 orphan으로 보존(데이터 유지, 태그만 제거)
+    // 태그가 그대로 보존되어 tag 필터 serve에도 계속 노출된다
     const [k] = await apiClient.listAllKeysToServe(projectId!)
     assert.equal(k.keyName, 'gone.key')
-    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
+    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [{ tag: 'web4', source: 'main' }])
 
-    // tag 필터 serve는 orphan을 자연 제외
     const served = await apiClient.listKeysToServeByTag(projectId!, 'web4')
-    assert.deepEqual(served.map(k => k.keyName), [])
+    assert.deepEqual(served.map(k => k.keyName), ['gone.key'])
   })
 
-  it('full sync removes all orphan contexts and then unclaims (tag) (context-ful, multi-context)', async () => {
-    // Android 같은 context-ful 도메인에서 서버 context 여러 개가 로컬에서 모두 사라진 케이스.
-    // 모든 orphan context를 빠짐없이 제거해야 한다 — Pass 1에서 baseMetadata를 누적하지 않으면
-    // pushSetMetadata replace 때문에 마지막 iteration만 살아남는 회귀가 있었다. 모든 context가
-    // 빠지면 그 다음 (tag) source-omitted unclaim까지 동일 PUT으로 보낸다.
-    await seedKeys(projectId!, [{
-      keyName: '취소',
-      tags: [{ tag: 'android-likey', source: 'main' }],
-      metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a', 'b']) }],
-    }])
-
-    const config = buildL10nConfig(projectId!, { source: 'main' })
-    await syncTransToL10nStorage(config, buildDomainConfig(), 'android-likey', [], {}, false)
-
-    const [k] = await apiClient.listAllKeysToServe(projectId!)
-    assert.equal(k.keyName, '취소')
-    assert.deepEqual(k.tags.map(t => ({ tag: t.tag, source: t.source })), [])
-    const ctxMeta = k.metadata.find(m => m.tag === 'android-likey' && m.metaKey === 'context')
-    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), [])
-  })
-
-  it('full sync removes only missing contexts and preserves the tag when others remain', async () => {
-    // 로컬에 일부 context가 남아 있으면 빠진 context만 제거하고 (tag, source)는 그대로 둔다.
-    // context가 줄어들 뿐 키는 여전히 코드에서 사용되므로 unclaim 대상이 아니다.
-    await seedKeys(projectId!, [{
-      keyName: '취소',
-      tags: [{ tag: 'android-likey', source: 'main' }],
-      metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a', 'b']) }],
-    }])
-
-    const config = buildL10nConfig(projectId!, { source: 'main' })
-    await syncTransToL10nStorage(
-      config, buildDomainConfig(), 'android-likey',
-      [key('취소', { context: 'a' })], {}, false,
-    )
-
-    const [k] = await apiClient.listAllKeysToServe(projectId!)
-    // 태그는 보존
-    assert.deepEqual(
-      k.tags.map(t => ({ tag: t.tag, source: t.source })),
-      [{ tag: 'android-likey', source: 'main' }],
-    )
-    // 'b'만 제거되고 'a'는 남음
-    const ctxMeta = k.metadata.find(m => m.tag === 'android-likey' && m.metaKey === 'context')
-    assert.deepEqual(JSON.parse(ctxMeta!.metaValue), ['a'])
-  })
-
-  it('tag-filtered fetch isolates cleanup — never touches keys tagged with a different tag', async () => {
-    // sync는 자신이 다루는 태그에만 영향을 준다. 같은 프로젝트에 다른 태그(web)로만 존재하는 키는
-    // tag-filtered fetch에서 보이지 않으므로 web4 sync의 Pass 1 cleanup이 절대 건드릴 수 없다.
+  it('PR-scope sync cleanup isolates by tag — never touches keys tagged with a different tag', async () => {
+    // PR-scope sync(--source)는 자기 (tag, source) orphan만 정리하며, 자신이 다루는 태그에만 영향을 준다.
+    // 같은 프로젝트에 다른 태그(web)로만 존재하는 키는 tag-filtered fetch에서 보이지 않아 절대 건드릴 수 없다.
     await seedKeys(projectId!, [
-      { keyName: 'only.web4', tags: [{ tag: 'web4', source: 'main' }] },
+      { keyName: 'only.web4', tags: [{ tag: 'web4', source: 'PR-1' }] },
       { keyName: 'only.web', tags: [{ tag: 'web', source: 'main' }] },
     ])
 
     const config = buildL10nConfig(projectId!, { source: 'main' })
-    await syncTransToL10nStorage(config, buildDomainConfig(), 'web4', [], {}, false)
+    await syncTransToL10nStorage(config, buildDomainConfig(), 'web4', [], {}, false, { source: 'PR-1' })
 
     const all = await apiClient.listAllKeysToServe(projectId!)
     const w4 = all.find(k => k.keyName === 'only.web4')!
     const w = all.find(k => k.keyName === 'only.web')!
 
-    // only.web4는 전체 sync의 (web4, *) unclaim으로 orphan이 된다
+    // only.web4는 PR-scope self-cleanup으로 자기 (web4, PR-1)이 제거되어 orphan이 된다
     assert.deepEqual(w4.tags.map(t => ({ tag: t.tag, source: t.source })), [])
     // only.web은 다른 태그라 완전 보존
     assert.deepEqual(

--- a/packages/syncer-l10n-storage/src/l10n-storage.test.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.test.ts
@@ -287,11 +287,27 @@ describe('buildKeyChanges', () => {
     assert.equal(updatingKeys.length, 0)
   })
 
-  it('Pass 1 (full sync): drops the orphan context and then unclaims (tag, *) source-agnostically', () => {
-    // context-ful 도메인에서 서버에 등록된 context가 로컬에 더 이상 없는 경우. 우선 context metadata에서
-    // 빠진 context를 제거하고, 한 키의 모든 context가 사라지면 (tag, *)를 source 무관 일괄 unclaim한다.
-    // 전체 sync는 이 태그 전체 범위를 정리할 권한이 있어 다른 source의 (tag, source) 행도 함께
-    // 정리한다 — 키 자체는 데이터 보존(orphan) 상태로 남는다.
+  it('Pass 1 (full sync): does NOT unclaim a key gone from local (context-less)', () => {
+    // 전체 sync는 특정 커밋 diff에 묶이지 않은 스냅샷 정합 작업이라 "코드에서 지워진 키"와 "아직
+    // 머지되지 않은 다른 PR이 추가해 둔 키"를 구분할 수 없다. 잘못 unclaim하면 미머지 PR의 claim을
+    // 조용히 삭제하는 데이터 손실이 생기므로, 로컬에 없는 키를 unclaim하지 않는다. (이전엔 즉시 unclaim했음)
+    const keyEntries: KeyEntry[] = []
+    const listedKeyMap = {
+      'gone.key': createL10nKey('gone.key', {
+        id: 'key-2',
+        tags: [{ tag: 'web4', source: 'main' }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'web4', keyEntries, {}, listedKeyMap,
+    )
+
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('Pass 1 (full sync): does NOT unclaim or prune contexts for a key gone from local (context-ful)', () => {
+    // context-ful 도메인에서도 동일 — 로컬에 없는 키의 (tag) unclaim도, orphan context 제거도 하지 않는다.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
       'removed.key': createL10nKey('removed.key', {
@@ -305,17 +321,30 @@ describe('buildKeyChanges', () => {
       'main', 'backend', keyEntries, {}, listedKeyMap,
     )
 
-    assert.equal(updatingKeys.length, 1)
-    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend' }])
-    const ctxMeta = updatingKeys[0].setMetadata?.find(m => m.metaKey === 'context')
-    assert.ok(ctxMeta != null)
-    assert.deepEqual(JSON.parse(ctxMeta.metaValue), [])
+    assert.equal(updatingKeys.length, 0)
   })
 
-  it('Pass 1 (full sync): unclaims (tag, *) regardless of which source claimed it', () => {
-    // 전체 sync는 tag 단위 정리 책임을 가진다. 다른 source(예: 폐기된 PR-N)가 단 (tag, source) 행도
-    // 함께 unclaim된다 — server는 source 생략된 removeTags를 (key, tag)의 모든 row 제거로 해석한다.
-    // 키 자체는 orphan으로 보존되어 같은 키가 다시 등장하면 부활한다.
+  it('Pass 1 (full sync): does NOT prune orphan contexts for a key still present in local', () => {
+    // 키가 로컬에 살아있고 일부 context만 빠진 경우에도 전체 sync는 context metadata를 건드리지 않는다.
+    // "빠진 context"가 정말 삭제된 건지, 미머지 PR이 쓰는 context인지 구분할 수 없기 때문. (이전엔 제거했음)
+    const keyEntries = [createKeyEntry('취소', { context: 'a' })]
+    const listedKeyMap = {
+      취소: createL10nKey('취소', {
+        tags: [{ tag: 'android-likey', source: 'main' }],
+        metadata: [{ tag: 'android-likey', metaKey: 'context', metaValue: JSON.stringify(['a', 'b']) }],
+      }),
+    }
+
+    const { updatingKeys } = buildKeyChanges(
+      'main', 'android-likey', keyEntries, {}, listedKeyMap,
+    )
+
+    // context 'a'는 이미 서버에 있어 Pass 2 변경도 없음 → 아무 업데이트 없음
+    assert.equal(updatingKeys.length, 0)
+  })
+
+  it('Pass 1 (full sync): does NOT touch a key claimed only by another source', () => {
+    // 다른 source(예: 미머지/폐기 PR-N)만 가진 키도 전체 sync는 건드리지 않는다.
     const keyEntries: KeyEntry[] = []
     const listedKeyMap = {
       'other.key': createL10nKey('other.key', {
@@ -327,31 +356,7 @@ describe('buildKeyChanges', () => {
       'main', 'backend', keyEntries, {}, listedKeyMap,
     )
 
-    assert.equal(updatingKeys.length, 1)
-    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'backend' }])
-    // 공유 context/description metadata는 건드리지 않는다 — 어차피 unclaim으로 자연 정리.
-    assert.equal(updatingKeys[0].setMetadata, undefined)
-  })
-
-  it('Pass 1 (full sync): context-less domain unclaims (tag, *) immediately when key is gone locally', () => {
-    // web4 vue-i18n 처럼 context metadata가 없는 도메인에서, 로컬 추출에 없는 키는 즉시 unclaim한다.
-    // 기존 코드는 context iteration을 거치므로 context-less 도메인의 orphan을 정리하지 못했다.
-    const keyEntries: KeyEntry[] = []
-    const listedKeyMap = {
-      'gone.key': createL10nKey('gone.key', {
-        id: 'key-2',
-        tags: [{ tag: 'web4', source: 'main' }],
-      }),
-    }
-
-    const { updatingKeys } = buildKeyChanges(
-      'main', 'web4', keyEntries, {}, listedKeyMap,
-    )
-
-    assert.equal(updatingKeys.length, 1)
-    assert.equal(updatingKeys[0].keyId, 'key-2')
-    assert.deepEqual(updatingKeys[0].removeTags, [{ tag: 'web4' }])
-    assert.equal(updatingKeys[0].setMetadata, undefined)
+    assert.equal(updatingKeys.length, 0)
   })
 
   it('Pass 2: accumulates contexts when same keyName appears with multiple contexts (existing key)', () => {

--- a/packages/syncer-l10n-storage/src/l10n-storage.ts
+++ b/packages/syncer-l10n-storage/src/l10n-storage.ts
@@ -22,12 +22,10 @@ import type {
 } from './api-types.js'
 import {
   buildContextMetadata,
-  buildContextMetadataRemoving,
   buildDescriptionMetadata,
   buildGlobalMetadata,
   buildReferencesMetadata,
   buildTagMetadata,
-  getContextsFromMetadata,
 } from './metadata.js'
 
 function assertBijectiveLocaleSyncMap(localeSyncMap: { [locale: string]: string }): void {
@@ -58,8 +56,8 @@ export async function syncTransToL10nStorage(
   const source = options?.source ?? configSource
   // 두 가지 sync 모드를 구분한다.
   // - **전체 sync** (`source === configSource`, options.source 미지정): 이 태그의 모든 키를 대상으로
-  //   하는 sync. 로컬에 없는 키는 (tag) 자체를 source-omitted로 unclaim 가능. 새 키가 추가될 때
-  //   특정 PR이 아니므로 default source(configSource, 보통 'main')가 부여된다.
+  //   하는 스냅샷 정합 sync. 새 키가 추가될 때 특정 PR이 아니므로 default source(configSource, 보통
+  //   'main')가 부여된다. 단, 로컬에 없는 키의 unclaim/context 정리는 하지 않는다(Pass 1 참고).
   // - **특정 source sync** (`options.source = 'PR-N'`): PR 스코프 sync. 자기 (tag, source) 범위만
   //   관리하고 다른 source의 claim/공유 metadata는 절대 건드리지 않는다.
   // main이 특별한 게 아니라, "특정 PR이 아닐 때 default source가 main"인 것일 뿐 main과 PR-N은 동등.
@@ -79,7 +77,8 @@ export async function syncTransToL10nStorage(
   // 1. 이 sync가 다루는 태그가 달린 키만 l10n-storage에서 조회 (keys-to-serve, tag-filtered).
   // 핵심 원칙: l10n-storage 호출은 항상 "태그"를 동반한다 — 이 프로젝트가 관리하는 키의 범위.
   // tag 필터는 orphan(어떤 태그/source에서도 claim되지 않은 키)을 자연 제외하므로, 결과는
-  // "이 태그로 claim된 키"의 정확한 집합이다. 로컬 추출에 없는 키는 unclaim 대상이 된다.
+  // "이 태그로 claim된 키"의 정확한 집합이다. 특정 source sync는 이 중 로컬 추출에서 사라진 자기
+  // (tag, source) 키를 unclaim 대상으로 본다(Pass 1). 전체 sync는 unclaim하지 않는다.
   // 로컬에는 있지만 listedKeyMap에 없는 키는 (a) 정말 새 키이거나 (b) 다른 태그로만 존재하는
   // 또는 orphan으로 부활시킬 키다 — 둘 다 Pass 2의 createKeys 경로가 서버 측에서 처리한다
   // (keyName 중복 시 서버가 자동으로 add-tag로 부활시킨다).
@@ -200,7 +199,6 @@ export function buildKeyChanges(
   creatingKeys: CreateL10nKeyInput[],
   updatingKeys: UpdateL10nKeyInput[],
 } {
-  const keys = EntryCollection.loadEntries(keyEntries)
   const creatingKeyMap: { [keyName: string]: CreateL10nKeyInput } = {}
   const updatingKeyMap: { [keyName: string]: UpdateL10nKeyInput } = {}
 
@@ -221,57 +219,20 @@ export function buildKeyChanges(
   }
 
   // Pass 1: 서버에 있는(이미 tag-filtered) 키 중 로컬 추출에 없는 것의 정리.
-  // - 전체 sync: 이 태그의 모든 키를 대상으로 하므로 로컬에 없는 키의 (tag) 자체를 source-omitted로
-  //   일괄 unclaim한다. context가 있는 도메인(Android 등)은 우선 로컬에 없는 context를 제거하고
-  //   context가 하나도 남지 않을 때만 unclaim한다. context-less 도메인(web4 vue-i18n 등)은 key
-  //   단위로 즉시 unclaim한다. PR 1161 단일-source 모델에서 (tag) PK당 source는 하나뿐이므로
-  //   source 생략은 그 한 row를 깨끗이 제거하며, 누구든 점유 중인 claim도 같이 정리된다.
-  // - 특정 source sync(예: --source PR-N): 공유 context는 절대 건드리지 않되, 로컬 추출에서 완전히
-  //   사라진 키의 자기 (tag, source) 태그만 제거한다. PR이 도중 추가했다가 도중 제거한 키의 자기
-  //   claim을 정리해 PR 체크런이 stale orphan으로 고착되는 회귀(#358)를 막는다. 자기 태그 제거는
-  //   다른 source에 영향을 주지 않아 안전하다.
-  if (isFullSync) {
-    for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
-      const serverContexts = getContextsFromMetadata(listedKey.metadata, tag)
-
-      if (serverContexts.length === 0) {
-        // context-less 도메인: 로컬에 없는 키면 즉시 (tag, *) unclaim.
-        if (entriesByKeyName.has(keyName)) continue
-        let updating = updatingKeyMap[keyName]
-        if (!updating) {
-          updating = { keyId: listedKey.id }
-          updatingKeyMap[keyName] = updating
-        }
-        pushRemoveTag(updating, { tag })
-        continue
-      }
-
-      // context-ful 도메인: 로컬에 없는 context는 제거하고, 다 빠지면 (tag, *) unclaim.
-      // 여러 context가 한 번에 빠질 때 buildContextMetadataRemoving이 매번 원본 listedKey.metadata만
-      // 보고 "그 context 하나만 빠진" 결과를 만들면 pushSetMetadata의 replace로 마지막 iteration만
-      // 살아남는다. baseMetadata를 누적해 매 iteration 직전 상태를 기준으로 다음 context를 빼야 모든
-      // orphan context가 빠진다.
-      let baseMetadata = listedKey.metadata
-      let touched = false
-      for (const keyContext of serverContexts) {
-        const keyEntry = keys.find(keyContext, keyName)
-        if (keyEntry != null) continue
-        const contextMeta = buildContextMetadataRemoving(baseMetadata, tag, keyContext)
-        if (contextMeta == null) continue
-        let updating = updatingKeyMap[keyName]
-        if (!updating) {
-          updating = { keyId: listedKey.id }
-          updatingKeyMap[keyName] = updating
-        }
-        pushSetMetadata(updating, contextMeta)
-        baseMetadata = mergeMetadata(baseMetadata, [contextMeta])
-        touched = true
-      }
-      if (touched && getContextsFromMetadata(baseMetadata, tag).length === 0) {
-        pushRemoveTag(updatingKeyMap[keyName]!, { tag })
-      }
-    }
-  } else {
+  // **특정 source sync(예: --source PR-N)만** 정리를 수행한다: 로컬 추출에서 완전히 사라진 키의 자기
+  // (tag, source) 태그만 제거한다. PR이 도중 추가했다가 도중 제거한 키의 자기 claim을 정리해 PR
+  // 체크런이 stale orphan으로 고착되는 회귀(#358)를 막는다. 자기 태그만 제거하고 공유 context는
+  // 건드리지 않으므로 다른 source에 영향을 주지 않아 안전하다.
+  //
+  // **전체 sync(source 미지정)는 어떤 unclaim/context 정리도 하지 않는다.** full sync는 특정 커밋
+  // diff에 묶이지 않은 스냅샷 정합 작업이라("Localizations (full)" 체크런의 Sync 버튼으로 임의 시점에
+  // 실행), "코드에서 지워진 키"와 "아직 머지되지 않은 다른 PR이 추가해 둔 키"를 신뢰성 있게 구분할
+  // 수단이 없다(둘 다 "서버엔 이 태그로 있는데 로컬엔 없음"으로 동일하게 보임). 잘못 unclaim하면
+  // 미머지 PR의 claim을 조용히 삭제하는 데이터 손실(되돌리기 어려움)이 발생하므로, 신뢰할 분류 수단이
+  // 마련되기 전까지는 정리하지 않는 쪽을 택한다. 그 대가로 지워진 키의 (tag, main) claim과 폐기 PR의
+  // orphan이 storage에 누적되지만(full 태그 전체 _remoteCount가 과대 집계됨), source-scoped PR
+  // 체크와 full compile-diff 체크의 동작은 영향받지 않는다.
+  if (!isFullSync) {
     for (const [keyName, listedKey] of Object.entries(listedKeyMap)) {
       if (!hasTag(listedKey.tags, tag, source)) continue
       // 로컬 추출에 아직 있으면 Pass 2에서 처리(claim 유지). 사라진 키만 orphan으로 본다.

--- a/packages/syncer-l10n-storage/src/metadata.ts
+++ b/packages/syncer-l10n-storage/src/metadata.ts
@@ -26,14 +26,6 @@ export function buildContextMetadata(existingMetadata: L10nKeyMetadata[], tag: s
   return { tag, metaKey: 'context', metaValue: JSON.stringify(updated) }
 }
 
-export function buildContextMetadataRemoving(existingMetadata: L10nKeyMetadata[], tag: string, context: string | null): L10nKeyMetadata | null {
-  if (!context) return null
-  const existing = getContextsFromMetadata(existingMetadata, tag)
-  const updated = existing.filter(c => c !== context)
-  if (updated.length === existing.length) return null
-  return { tag, metaKey: 'context', metaValue: JSON.stringify(updated) }
-}
-
 // --- Description (comments) ---
 
 export function getDescriptionFromMetadata(metadata: L10nKeyMetadata[], tag: string): string[] {


### PR DESCRIPTION
## Summary

전체 sync(source 미지정)가 로컬 추출에 없는 태그-claim 키를 모두 unclaim하고 orphan context까지 제거하던 동작을 제거합니다. full sync는 특정 커밋 diff에 묶이지 않은 스냅샷 정합 작업이라 "코드에서 지워진 키"와 "아직 머지되지 않은 다른 PR이 추가해 둔 키(PR-scope sync로 claim됨)"를 구분할 수 없어, 잘못 unclaim하면 활성 PR의 claim을 조용히 삭제하는 데이터 손실이 발생했습니다.

Pass 1 cleanup은 이제 **source-scoped(PR-N) sync에서만** 동작하여 자기 `(tag, source)`만 안전하게 제거합니다(#358 가드 유지). 트레이드오프로 지워진 키의 `(tag, main)` claim과 폐기 PR orphan이 storage에 누적되지만, source-scoped PR 체크와 full compile-diff 체크의 동작은 영향받지 않습니다.

## Test plan

- [x] 유닛 테스트 재작성: full sync가 unclaim/context-prune를 하지 않음(context-less/context-ful 키 소실, live 키 부분 context, 타 source 키), PR-scope self-cleanup·claim 회귀 가드 유지 — 48개 통과
- [] POST-MERGE: 실제 prod에서 미머지 PR이 추가한 키가 main full sync(Sync 버튼) 후에도 claim 유지되는지 dry-sync로 확인
- [ ] POST-MERGE: 누적되는 stale `(tag, main)`/폐기 PR orphan 정리 방안(신뢰 분류기 또는 별도 스윕) 별도 논의

🤖 Generated with [Claude Code](https://claude.com/claude-code)