### PR TITLE
chore: manage github-actions versions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
           - "htmlparser2"
           - "domhandler"
           - "domutils"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
GitHub Actions 버전을 Dependabot으로 관리합니다 (weekly, cooldown 14일). tpc-agent에서 검증한 설정과 동일합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)