### PR TITLE
ci: 테스트 매트릭스에 node 26 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [22, 24]
+        version: [22, 24, 26]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

`test.yml`의 node 버전 매트릭스를 `[22, 24]` → `[22, 24, 26]`으로 확장합니다.

`engines`는 `>=22.19.0` / `>=10.9.0` 그대로 유지하므로 **지원 범위 변경이나 소비자 영향은 없습니다.** 새 node major에서 미리 깨짐을 감지하는 목적입니다.

매트릭스가 있는 워크플로우는 `test.yml` 하나뿐이라 다른 워크플로우는 건드리지 않았습니다. `e2e.yml`은 실제 tpc-agent 백엔드와의 HTTP 계약을 검증하는 성격이라 node 버전별로 갈릴 여지가 적고, 매트릭스화하면 GCP 인증 + docker compose 기동 비용이 3배가 되므로 22 고정을 유지합니다.

## Test plan

- [x] node 26 잡이 red일 경우, 원인이 우리 코드인지 툴체인(tsc / oxlint-tsgolint)의 node 26 미지원인지 구분해서 대응 — **Test (26) 32s pass**, 코드·툴체인 모두 node 26에서 문제 없어 추가 대응 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)