### PR TITLE
ci: release-please PR을 GitHub App 토큰으로 생성

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,17 +9,19 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     concurrency: release-please
-    permissions:
-      contents: write
-      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.TPC_AGENT_CLIENT_ID }}
+          private-key: ${{ secrets.TPC_AGENT_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: ${{ github.ref_name }}
 
   publish:


### PR DESCRIPTION
## Summary

`GITHUB_TOKEN`으로 생성된 release PR은 워크플로우가 정상 트리거되지 않아, public 리포인 이 저장소에서는 `Test`/`E2E Tests`/`pkg-pr-new`가 매번 `action_required`(Approve workflows to run) 상태로 멈췄습니다. `tpc-agent`·`oxlint-config`와 동일하게 TPC-AGENT GitHub App 토큰으로 release PR을 생성해 승인 클릭 없이 CI가 돌게 합니다.

App 토큰이 권한을 갖게 되므로 `release-please` job의 `GITHUB_TOKEN` 권한 선언(`contents`/`pull-requests: write`)은 제거했습니다.

org secret `TPC_AGENT_PRIVATE_KEY`, org variable `TPC_AGENT_CLIENT_ID`는 이 리포에서 접근 가능하도록 이미 공유해 두었습니다.

## Test plan

- [ ] POST-MERGE: main 푸시로 release-please 워크플로우가 App 토큰 발급에 성공하는지 확인
- [ ] POST-MERGE: 새로 생성/갱신된 release PR의 작성자가 `tpc-agent[bot]`인지, `Test`/`E2E Tests`/`pkg-pr-new`가 승인 없이 실행되는지 확인
- [ ] POST-MERGE: 기존 PR #384는 `github-actions[bot]` 작성이라 승인이 여전히 필요 — 머지 후 새 release PR부터 적용됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U55ye4d19WQhKTEVmfn3M8