### PR TITLE
ci: packageManager 필드로 Dependabot npm 버전을 10으로 고정

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=22.19.0",
     "npm": ">=10.9.0"
   },
+  "packageManager": "npm@10.9.8",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
## Summary
Dependabot updater가 `engines.npm` (`>=10.9.0`)을 읽고 자기가 지원하는 최신 메이저인 npm 11을 corepack으로 활성화해 lockfile을 갱신하고 있었습니다 ([해당 로그](https://github.com/tpcint/l10n-tools/actions/runs/30282597215/job/90032457710): `Returned (engines) info "npm" : "11"` → `Installing "npm@11"`). 로컬 개발 환경은 npm 10이라 lockfile 갱신 주체가 엇갈립니다.

dependabot-core의 npm 버전 결정 우선순위가 `packageManager` → `engines` → `lockfileVersion` 순이므로, `packageManager: "npm@10.9.8"`을 명시해 Dependabot이 npm 10을 쓰게 합니다. `engines`는 그대로 두어 패키지 소비자 쪽 제약은 유지합니다 (`packageManager`는 dependent 쪽에서 검사되지 않는 개발용 메타데이터).

## Test plan
- [x] `npm install --package-lock-only` 실행 후 package-lock.json 무변경 확인 (이 필드는 lock에 기록되지 않음)
- [ ] POST-MERGE: 다음 Dependabot 실행 로그에서 `Installing "npm@10.9.8"` (engines 기반 npm 11 아님) 확인
- [ ] POST-MERGE: 이후 Dependabot PR의 package-lock.json diff가 npm 10 기준으로 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)